### PR TITLE
add label for search input

### DIFF
--- a/src/hexo/themes/documentation/layout/partials/header.hbs
+++ b/src/hexo/themes/documentation/layout/partials/header.hbs
@@ -18,7 +18,8 @@
                 {{/each}}
             </ul>
             <div class="nav-bar__input">
-                <input type="search" id="search-input" placeholder="Search…">
+                <label for="search-input" class="visually-hidden">Search the documentation</label>
+                <input type="search" id="search-input" placeholder="Search…" aria-label="Search">
             </div>
         </nav>
         <button class="header__toggle mobile-nav-button" aria-label="Menu"></button>


### PR DESCRIPTION
@molant this will fix one of the search input a11y warnings we get. 

Added label for the search documentation input but am visually hiding it. 