### PR TITLE
change floating animation property from top to transform

### DIFF
--- a/src/hexo/themes/documentation/source/core/css/home.css
+++ b/src/hexo/themes/documentation/source/core/css/home.css
@@ -71,15 +71,15 @@ main {
     @keyframes floating {
 
         0% {
-            top: -10px;
+            transform: translateY(-10px);
         }
 
         50% {
-            top: 0;
+            transform: translateY(0);
         }
 
         100% {
-            top: -10px;
+            transform: translateY(-10px);
         }
     }
 


### PR DESCRIPTION
Floating animation is not so smooth since it animates top property and is causing repaint. Using transform can animate illustrations within composite layer and make it smooth.