### PR TITLE
Fix: Fix the broken `changelog` page

### DIFF
--- a/helpers/update-content.js
+++ b/helpers/update-content.js
@@ -20,4 +20,5 @@ cp('-R', `${TMP_DIR}/docs/about`, `${SOURCE_DIR}`);
 cp(`${TMP_DIR}/CHANGELOG.md`, `${SOURCE_DIR}/about`);
 cp(`${TMP_DIR}/CODE_OF_CONDUCT.md`, `${SOURCE_DIR}/about`);
 
+rm('-rf', `${SOURCE_DIR}/about/CONTRIBUTORS.md`);
 rm('-rf', TMP_DIR);

--- a/src/hexo/source/contributors.md
+++ b/src/hexo/source/contributors.md
@@ -1,0 +1,5 @@
+---
+title: contributors
+category: about
+permalink: about/CONTRIBUTORS.html
+---

--- a/src/hexo/themes/documentation/layout/index.hbs
+++ b/src/hexo/themes/documentation/layout/index.hbs
@@ -62,11 +62,7 @@
                 pages=(sortPagesByCategory site.pages.data 'user-guide')}}
             {{/compare}}
 
-            {{#compare page.category 'belongsTo' 'doc-index, about-index'}}
-                {{>single-page}}
-            {{/compare}}
-
-            {{#compare page.title 'belongsTo' 'changelog, code-of-conduct, faq, governance'}}
+            {{#compare page.category 'belongsTo' 'doc-index, about-index, about'}}
                 {{>single-page}}
             {{/compare}}
 


### PR DESCRIPTION
* include `changelog` into the rendering list
* remove `contributors` page after copying
* add a placeholder page for `contributors`

Fix #107