### PR TITLE
Fix web.config to allow auto-renew of ssl certs

### DIFF
--- a/web.config
+++ b/web.config
@@ -33,16 +33,16 @@
                 </rule>
             </outboundRules>
             <rules>
-                <rule name="Redirect to https" stopProcessing="true">
-                    <match url="(.*)"/>
-                    <conditions>
-                        <add input="{HTTPS}" pattern="off" ignoreCase="true"/>
-                        <add input="{WARMUP_REQUEST}" pattern="1" negate="true" />
-                        <add input="{REQUEST_URI}" pattern="/api/version/" negate="true" />
-                    </conditions>
-                    <action type="Redirect" url="https://{HTTP_HOST}{REQUEST_URI}" redirectType="Permanent"
-                        appendQueryString="false"/>
-                </rule>
+                <!-- <rule name="Redirect to https" stopProcessing="true"> -->
+                <!--     <match url="(.*)"/> -->
+                <!--     <conditions> -->
+                <!--         <add input="{HTTPS}" pattern="off" ignoreCase="true"/> -->
+                <!--         <add input="{WARMUP_REQUEST}" pattern="1" negate="true" /> -->
+                <!--         <add input="{REQUEST_URI}" pattern="/api/version/" negate="true" /> -->
+                <!--     </conditions> -->
+                <!--     <action type="Redirect" url="https://{HTTP_HOST}{REQUEST_URI}" redirectType="Permanent" -->
+                <!--         appendQueryString="false"/> -->
+                <!-- </rule> -->
 
                 <rule name="static">
                     <match url="(?!scanner|search).*$" ignoreCase="true"/>

--- a/web.config
+++ b/web.config
@@ -33,23 +33,25 @@
                 </rule>
             </outboundRules>
             <rules>
-                <!-- <rule name="Redirect to https" stopProcessing="true"> -->
-                <!--     <match url="(.*)"/> -->
-                <!--     <conditions> -->
-                <!--         <add input="{HTTPS}" pattern="off" ignoreCase="true"/> -->
-                <!--         <add input="{WARMUP_REQUEST}" pattern="1" negate="true" /> -->
-                <!--         <add input="{REQUEST_URI}" pattern="/api/version/" negate="true" /> -->
-                <!--     </conditions> -->
-                <!--     <action type="Redirect" url="https://{HTTP_HOST}{REQUEST_URI}" redirectType="Permanent" -->
-                <!--         appendQueryString="false"/> -->
-                <!-- </rule> -->
-
-                <rule name="static">
+                <rule name="Redirect to https" stopProcessing="true">
+                    <match url="(.*)"/>
+                    <conditions>
+                        <add input="{HTTPS}" pattern="off" ignoreCase="true"/>
+                        <add input="{WARMUP_REQUEST}" pattern="1" negate="true" />
+                        <add input="{REQUEST_URI}" pattern="/api/version/" negate="true" />
+                    </conditions>
+                    <action type="Redirect" url="https://{HTTP_HOST}{REQUEST_URI}" redirectType="Permanent"
+                        appendQueryString="false"/>
+                </rule>
+                <rule name="wellknown" stopProcessing="true">
+                    <match url="^\.well-known.*" />
+                    <action type="Rewrite" url="{REQUEST_URI}"/>
+                </rule>
+                <rule name="static" stopProcessing="true">
                     <match url="(?!scanner|search).*$" ignoreCase="true"/>
                     <action type="Rewrite" url="dist{REQUEST_URI}"/>
                 </rule>
-
-                <rule name="ScannerAndSearch">
+                <rule name="ScannerAndSearch" stopProcessing="true">
                     <match url="(?:scanner|search)(.*)$" ignoreCase="true"/>
                     <conditions>
                         <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="True"/>


### PR DESCRIPTION
This fixes the issues we had auto-renewing the certificates of let's encrypt. There were 2 issues:

- The website was changed to x64 and the extension was for x86 so it couldn't run
- It was impossible to access the `.well-known` folder