### PR TITLE
Fix #197

### DIFF
--- a/src/hexo/themes/documentation/layout/partials/sub-page.hbs
+++ b/src/hexo/themes/documentation/layout/partials/sub-page.hbs
@@ -34,6 +34,9 @@
     </header>
     <div class="section">
         <div class="layout layout--sidebar">
+            <div class="module module--primary wrap-text">
+                {{{page.content}}}
+            </div>
             <div class="module module--secondary table-of-contents treeview" role="navigation">
                 <ul role="tree" aria-labelledby="page-heading" tabindex="0">
                 {{#each (getSortedToCTitles pages)}}
@@ -77,9 +80,6 @@
                     </li>
                 {{/each}}
                 </ul>
-            </div>
-            <div class="module module--primary wrap-text">
-                {{{page.content}}}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Reverting layout of documentation pages, will revisit the design of tree-view on mobile for a better solution