### PR TITLE
Chore: Link to user guide rules from homepage

### DIFF
--- a/src/hexo/themes/documentation/layout/partials/home.hbs
+++ b/src/hexo/themes/documentation/layout/partials/home.hbs
@@ -44,7 +44,7 @@
                             </a>
                         </div>
                         <div class="module">
-                            <a href="/docs/developer-guide/rules/">
+                            <a href="/docs/user-guide/rules/">
                                 <img src="images/rules-icon.svg" class="icons--home" alt="" role="none">
                                 <p>Rules</p>
                             </a>


### PR DESCRIPTION
Currently the `rules` icon in the homepage links to the `how to develop a rule`. It should be linked to the index of rules in the `user guide`. 