### PR TITLE
Chore: normalize urls in public site

### DIFF
--- a/helpers/updater.js
+++ b/helpers/updater.js
@@ -117,15 +117,12 @@ const generateFrontMatterInfo = (filePath, title, description, currentFrontMatte
         relativePath = path.relative('docs', relativePath);
         root = 'docs';
     }
-    baseName = path.basename(relativePath, '.md');
-    const indexMatch = baseName.match(/(^\d+)-/);
 
-    if (indexMatch) {
-        baseName = baseName.replace(indexMatch.pop(), '');
-    }
+    baseName = path.basename(relativePath, '.md');
+    baseName = baseName !== 'index' ? baseName : '';
 
     const [category, tocTitle] = path.dirname(relativePath).split(path.sep);
-    const permalink = normalize(path.join(root, path.dirname(relativePath), `${baseName}.html`)).toLowerCase();
+    const permalink = normalize(path.join(root, path.dirname(relativePath), baseName, 'index.html')).toLowerCase();
     const layout = getLayout(filePath);
 
     const newFrontMatter = {

--- a/src/hexo/source/404.md
+++ b/src/hexo/source/404.md
@@ -1,6 +1,6 @@
 ---
 category: "placeholder-pages"
 layout: "error"
-permalink: "404.html"
+permalink: "404/index.html"
 title: "Oh oh"
 ---

--- a/src/hexo/source/_data/menu.yml
+++ b/src/hexo/source/_data/menu.yml
@@ -22,16 +22,16 @@
   items:
   - id: faq
     title: FAQ
-    link: /about/faq.html
+    link: /about/faq/
   - id: changelog
     title: Changelog
-    link: /about/changelog.html
+    link: /about/changelog/
   - id: governance
     title: Governance
-    link: /about/governance.html
+    link: /about/governance/
   - id: contributors
     title: Contributors
-    link: /about/contributors.html
+    link: /about/contributors/
   - id: code-of-conduct
     title: Code of Conduct
     link: https://js.foundation/community/code-of-conduct

--- a/src/hexo/source/about.md
+++ b/src/hexo/source/about.md
@@ -5,8 +5,8 @@ layout: "about"
 permalink: "about/index.html"
 title: "About"
 ---
-* [Changelog](CHANGELOG.md)
+* [Changelog](about/CHANGELOG.md)
 * [Code of Conduct](https://js.foundation/community/code-of-conduct)
-* [Contributors](CONTRIBUTORS.md)
-* [FAQ](FAQ.md)
-* [Governance](GOVERNANCE.md)
+* [Contributors](about/CONTRIBUTORS.md)
+* [FAQ](about/FAQ.md)
+* [Governance](about/GOVERNANCE.md)

--- a/src/hexo/source/contributors.md
+++ b/src/hexo/source/contributors.md
@@ -2,6 +2,6 @@
 category: "about"
 description: "List of people that have contributed to sonar"
 layout: "about"
-permalink: "about/contributors.html"
+permalink: "about/contributors/index.html"
 title: "Contributors"
 ---

--- a/src/hexo/themes/sonarwhal/helper/index.js
+++ b/src/hexo/themes/sonarwhal/helper/index.js
@@ -54,7 +54,7 @@ const ruleStatus = {
 
 module.exports = function () {
     const isIndexPage = (page) => {
-        return page.permalink.endsWith('index.html');
+        return page.source.endsWith('index.md');
     };
 
     const isGuideIndexPage = (page) => {
@@ -110,6 +110,13 @@ module.exports = function () {
     };
 
     return {
+        /* eslint-disable object-shorthand */
+        capitalize: function (str) {
+            const filtered = str.replace(/[^a-zA-Z0-9]/g, ' ');
+
+            return filtered.charAt(0).toUpperCase() + filtered.slice(1);
+        },
+        /* eslint-enable object-shorthand */
         /**
          * Handlebars Comparison Helpers
          * Copyright (c) 2013 Jon Schlinkert, Brian Woodward, contributors
@@ -276,6 +283,9 @@ module.exports = function () {
             // returns whether or not a page is a subpage under developer guide or user-guide
             return !isGuideIndexPage(page);
         },
+        isNotSectionIndexPage: (page) => {
+            return !isSectionIndexPage(page);
+        },
         isPending: (status) => {
             return status === jobStatus.pending;
         },
@@ -317,6 +327,9 @@ module.exports = function () {
         },
         pluralize: (text, count) => {
             return `${text}${count === 1 ? '' : 's'}`;
+        },
+        sanitize: (permalink) => {
+            return permalink.replace(/\/index.html/g, '');
         },
         setDefault: (...values) => {
             return values.reduce((accumulator, value) => {

--- a/src/hexo/themes/sonarwhal/layout/partials/contributors.hbs
+++ b/src/hexo/themes/sonarwhal/layout/partials/contributors.hbs
@@ -3,7 +3,7 @@
         <nav class="container breadcrumb" aria-label="breadcrumbs">
             <ul>
                 <li><a href="/">Home</a></li>
-                <li><a href="index.html">About</a></li>
+                <li><a href="../">About</a></li>
                 <li>Contributors</li>
             </ul>
         </nav>

--- a/src/hexo/themes/sonarwhal/layout/partials/sub-page.hbs
+++ b/src/hexo/themes/sonarwhal/layout/partials/sub-page.hbs
@@ -7,12 +7,8 @@
             </li>
             {{#if (isNotGuideIndexPage page)}}
             <li>
-                <a href="../" class="guide-category">
-                    {{#compare page.category '===' 'user-guide'}}
-                        User guide
-                    {{else}}
-                        Developer guide
-                    {{/compare}}
+                <a  href="../{{#if (isNotSectionIndexPage page)}}../{{/if}}" class="guide-category">
+                    {{capitalize page.category}}
                 </a>
             </li>
             {{/if}}
@@ -67,7 +63,7 @@
                                             {{else}}
                                                 class="toc-subsection-title"
                                             {{/compare}}>
-                                        <a class="text" href="{{permalink}}"
+                                        <a class="text" href="{{sanitize permalink}}"
                                             {{#compare ../../page.tocTitle '!==' ../this}}
                                                 tabindex="-1"
                                             {{/compare}}>

--- a/src/hexo/themes/sonarwhal/scripts/link-filter.js
+++ b/src/hexo/themes/sonarwhal/scripts/link-filter.js
@@ -5,15 +5,22 @@ hexo.extend.filter.register('before_post_render', (data) => {
     // - is enclosed in parenthesis pairs
     // - doesn't start with `http`, `https` or `ftp`
     // - endes with `.md`
-    // Examples:
-    // - (../rules/how-to-interact-with-other-services.md) => (../rules/how-to-interact-with-other-services.html)
-    // - (../index.md#rule-configuration) => (../index.html#rule-configuration)
     const mdUrlRegex = /\((?!http|https|ftp)([^(|)]+\.md)[^(|)]*\)/g;
     let match;
 
     while ((match = mdUrlRegex.exec(data.content)) !== null) {
         const matchMdUrl = match[0];
-        const matchHtmlUrl = matchMdUrl.replace('.md', '.html');
+        let matchHtmlUrl = matchMdUrl.replace(/(?:\/index)?.md/g, '/');
+        // Examples:
+        // - (../rules/how-to-interact-with-other-services.md) => (../rules/how-to-interact-with-other-services/)
+        // - (../index.md#rule-configuration) => (../#rule-configuration)
+
+        if (!data.source.includes('index.md')) {
+            // Due to the one more directory level added after converting permalinks.
+            // i.e. ../faq.md => ../faq/index.html
+            // If we want to back out from faq to go to other pages, we need to back out one more time.
+            matchHtmlUrl = matchHtmlUrl.replace(/\((.*?)\)/g, '(../$1)');
+        }
 
         data.content = data.content.replace(matchMdUrl, matchHtmlUrl);
     }

--- a/src/hexo/themes/sonarwhal/source/js/scanner-submit.js
+++ b/src/hexo/themes/sonarwhal/source/js/scanner-submit.js
@@ -97,7 +97,7 @@
                         <div class="rule-result--details__header"> \
                             <p class="rule-title">{{name}}: {{getLength messages status}}</p> \
                             <div class="rule-result__docs"> \
-                                <a href="https://sonarwhal.com/docs/user-guide/rules/{{name}}.html" title="documentation for {{name}} rule"><img src="/images/results-docs-icon.svg" alt="" class="docs-icon" /></a> \
+                                <a href="https://sonarwhal.com/docs/user-guide/rules/{{name}}/" title="documentation for {{name}} rule"><img src="/images/results-docs-icon.svg" alt="" class="docs-icon" /></a> \
                                 <button title="show warning details" class="button--details">Open Details</button> \
                             </div> \
                         </div> \

--- a/web.config
+++ b/web.config
@@ -55,7 +55,7 @@
                 <rule name="Redirect to JSF CoC" stopProcessing="true">
                     <match url="(.*)"/>
                     <conditions>
-                         <add input="{REQUEST_URI}" pattern="/about/code_of_conduct.html" />
+                         <add input="{REQUEST_URI}" pattern="/about/code_of_conduct/" />
                     </conditions>
                     <action type="Redirect" url="https://js.foundation/community/code-of-conduct" redirectType="Permanent"
                         appendQueryString="true"/>
@@ -102,7 +102,7 @@
 
         <httpErrors errorMode="Custom" defaultResponseMode="ExecuteURL">
             <remove statusCode="404" subStatusCode="-1"/>
-            <error statusCode="404" path="/dist/404.html" responseMode="ExecuteURL"/>
+            <error statusCode="404" path="/dist/404/" responseMode="ExecuteURL"/>
         </httpErrors>
 
         <iisnode watchedFiles="web.config;*.js" debuggingEnabled="false"/>
@@ -142,6 +142,6 @@
         </staticContent>
     </system.webServer>
     <system.web>
-        <customErrors mode="RemoteOnly" defaultRedirect="/dist/404.html" redirectMode="ResponseRewrite"/>
+        <customErrors mode="RemoteOnly" defaultRedirect="/dist/404/" redirectMode="ResponseRewrite"/>
     </system.web>
 </configuration>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonar)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html#commitmessages)

## Short description of the change(s)
Fix #229

1. In `updater`,  permalinks are changed from `/about/faq.html` to `/about/faq/index.html`. This tells hexo to render `faq.md` into its own folder and both  `about/faq` ,  `about/faq/` work as functional urls yet `index.html` doesn't show in the address bar.
2. Add helper so that `index.html` is omitted when `permalink` is cited anywhere in the templated.
3. Edit hexo filter `link-filter` so that it takes into account the fact that an extra directory level is added to the current page.

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
