### PR TITLE
Fix: fix treeview links in production

### DIFF
--- a/src/hexo/themes/sonarwhal/helper/index.js
+++ b/src/hexo/themes/sonarwhal/helper/index.js
@@ -329,7 +329,7 @@ module.exports = function () {
             return `${text}${count === 1 ? '' : 's'}`;
         },
         sanitize: (permalink) => {
-            return permalink.replace(/\/index.html/g, '');
+            return permalink.replace(/\/index.html/g, '/');
         },
         setDefault: (...values) => {
             return values.reduce((accumulator, value) => {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonar)
- [ ] Followed the [commit message guidelines](https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html#commitmessages)

## Short description of the change(s)

In production `https://sonarwhal.com/dist/docs/user-guide/rules` gets redirected to `https://sonarwhal.com/dist/docs/user-guide/rules/`, which returns 404. So the treeview is broken. Fix the links in treeview to all have `/` at the end of the links. But [this setting](https://github.com/sonarwhal/sonarwhal.com/blob/d7873ef9fb3ca184f30debc5b17593d35a757bc7/web.config#L69) in web.config might need to be changed so urls still work without slash. I'm not sure why the requests only  get redirected when there is no `/` at the end. @molant  

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
