### PR TITLE
Fix: Proximity of close details icon on scan results page

### DIFF
--- a/src/hexo/themes/sonarwhal/source/core/css/scan-results.css
+++ b/src/hexo/themes/sonarwhal/source/core/css/scan-results.css
@@ -287,16 +287,16 @@ button.button--details {
 .rule-result--details[aria-expanded="false"] .button--details::before {
     content: url("/images/results-view-details.svg");
     position: absolute;
-    left: 1rem;
-    width: 1.2rem;
+    left: .8rem;
+    width: 1rem;
     top: .6rem;
 }
 
 .rule-result--details[aria-expanded="true"] .button--details::before {
     content: url("/images/results-hide-details.svg");
     position: absolute;
-    left: 1rem;
-    width: 1.2rem;
+    left: .8rem;
+    width: 1rem;
     top: .6rem;
 }
 


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)
The close icon '-' for the close details button the scan results page was rendering
too close to the 'close' text in some browsers.

Fix #313
