### PR TITLE
New: Add opensearch in sonarwhal.com

### DIFF
--- a/src/hexo/themes/sonarwhal/layout/partials/metas.hbs
+++ b/src/hexo/themes/sonarwhal/layout/partials/metas.hbs
@@ -9,6 +9,7 @@
 <link rel="manifest" href="/site.webmanifest">
 
 <link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
+<link type="application/opensearchdescription+xml" rel="search" href="/opensearch.xml" title="sonarwhal">
 
 {{#if status}}
     {{#if (isFinish status)}}

--- a/src/hexo/themes/sonarwhal/source/opensearch.xml
+++ b/src/hexo/themes/sonarwhal/source/opensearch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>sonarwhal</ShortName>
+  <Description>sonarwhal documentation search</Description>
+  <Url type="text/html" method="get" template="https://sonarwhal.com/search?q={searchTerms}" />
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image height="16" width="16" type="image/x-icon">https://sonarwhal.com/images/favicon.ico</Image>
+  <moz:SearchForm>https://sonarwhal.com/search</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Fix #223

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [ ] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

- Chrome: 
  * Search engine is added only when site is visited without a path (according to http://dev.chromium.org/tab-to-search): sonarwhal.com ✔️ , sonarwhal.com/scanner ❌ 
  * To trigger open search, user needs to input `sonarwhal.com searchTerm` in the address bar
- Firefox:
  * To enable open search in the site, user needs to add `sonarwhal` to the search engine

![screenshot 2](https://user-images.githubusercontent.com/20218531/34420981-7b3f5572-ebc1-11e7-94d1-68a523b3aa3b.png)

- Edge:
  * Search engine installed when pathless page is visited.
  * Both the visited page and the xml file needs to be served over HTTPS.


<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
