### PR TITLE
New: Documentation ToC layout on mobile

### DIFF
--- a/src/hexo/source/_data/changelog.yml
+++ b/src/hexo/source/_data/changelog.yml
@@ -1,655 +1,694 @@
 ---
-  0.20.1 (Decembe 12, 2017):
-    Bug fixes / Improvements:
+  0.21.0 (January 4, 2018): 
+    Bug fixes / Improvements: 
+      raw: "- [[`c482c99844`](https://github.com/sonarwhal/sonarwhal/commit/c482c998446f63e14db17092910567f225f74c22)] - Fix: Sync connector certificate config with `requester`.\n- [[`f082067fe8`](https://github.com/sonarwhal/sonarwhal/commit/f082067fe8e69cc905c4ab85e02d10d9a9a0b1a9)] - Fix: Downgrade HTTP/2 headers in `rawResponse`.\n- [[`e3e1ca02d5`](https://github.com/sonarwhal/sonarwhal/commit/e3e1ca02d5db904a645184b389bb8d1186bf2227)] - Fix: Improve error message for unhandled promises.\n- [[`80c15103a1`](https://github.com/sonarwhal/sonarwhal/commit/80c15103a17958201333a327083de9561185ee24)] - Docs: Fix typos in `strict-transport-security.md` (see also: [`#729`](https://github.com/sonarwhal/sonarwhal/issues/729)).\n- [[`bd335c2c32`](https://github.com/sonarwhal/sonarwhal/commit/bd335c2c324721376af4fe7bb7d7690e5ca189b6)] - Docs: Add information on creating external rule (see also: [`#724`](https://github.com/sonarwhal/sonarwhal/issues/724)).\n- [[`10d1881a69`](https://github.com/sonarwhal/sonarwhal/commit/10d1881a69283e32681262f250db6f830fad0cda)] - Fix: Support external rules outside `@sonarwhal` (see also: [`#713`](https://github.com/sonarwhal/sonarwhal/issues/713)).\n- [[`742c9af408`](https://github.com/sonarwhal/sonarwhal/commit/742c9af4081b1c9a9a1eac128a3b79d4db17d06c)] - Docs: Fix link in `rules/http-cache.md` (see also: [`#723`](https://github.com/sonarwhal/sonarwhal/issues/723)).\n- [[`035fd4c9e5`](https://github.com/sonarwhal/sonarwhal/commit/035fd4c9e58cf8d6af803c24095e470f4fc11689)] - Docs: Add missing link in `connectors.md`.\n\n"
+      html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/c482c998446f63e14db17092910567f225f74c22\"><code>c482c99844</code></a>] - Fix: Sync connector certificate config with <code>requester</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f082067fe8e69cc905c4ab85e02d10d9a9a0b1a9\"><code>f082067fe8</code></a>] - Fix: Downgrade HTTP/2 headers in <code>rawResponse</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/e3e1ca02d5db904a645184b389bb8d1186bf2227\"><code>e3e1ca02d5</code></a>] - Fix: Improve error message for unhandled promises.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/80c15103a17958201333a327083de9561185ee24\"><code>80c15103a1</code></a>] - Docs: Fix typos in <code>strict-transport-security.md</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/729\"><code>#729</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/bd335c2c324721376af4fe7bb7d7690e5ca189b6\"><code>bd335c2c32</code></a>] - Docs: Add information on creating external rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/724\"><code>#724</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/10d1881a69283e32681262f250db6f830fad0cda\"><code>10d1881a69</code></a>] - Fix: Support external rules outside <code>@sonarwhal</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/713\"><code>#713</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/742c9af4081b1c9a9a1eac128a3b79d4db17d06c\"><code>742c9af408</code></a>] - Docs: Fix link in <code>rules/http-cache.md</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/723\"><code>#723</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/035fd4c9e58cf8d6af803c24095e470f4fc11689\"><code>035fd4c9e5</code></a>] - Docs: Add missing link in <code>connectors.md</code>.</li>\n</ul>\n"
+      details: 
+        c482c998446f63e14db17092910567f225f74c22: 
+          associateCommitId: null
+          message: "Fix: Sync connector certificate config with `requester`."
+        f082067fe8e69cc905c4ab85e02d10d9a9a0b1a9: 
+          associateCommitId: null
+          message: "Fix: Downgrade HTTP/2 headers in `rawResponse`."
+        e3e1ca02d5db904a645184b389bb8d1186bf2227: 
+          associateCommitId: null
+          message: "Fix: Improve error message for unhandled promises."
+        80c15103a17958201333a327083de9561185ee24: 
+          associateCommitId: "729"
+          message: "Docs: Fix typos in `strict-transport-security.md`."
+        bd335c2c324721376af4fe7bb7d7690e5ca189b6: 
+          associateCommitId: "724"
+          message: "Docs: Add information on creating external rule."
+        10d1881a69283e32681262f250db6f830fad0cda: 
+          associateCommitId: "713"
+          message: "Fix: Support external rules outside `@sonarwhal`."
+        742c9af4081b1c9a9a1eac128a3b79d4db17d06c: 
+          associateCommitId: "723"
+          message: "Docs: Fix link in `rules/http-cache.md`."
+        035fd4c9e58cf8d6af803c24095e470f4fc11689: 
+          associateCommitId: null
+          message: "Docs: Add missing link in `connectors.md`."
+    New features: 
+      raw: "- [[`db6337b220`](https://github.com/sonarwhal/sonarwhal/commit/db6337b2206b710b70f93bf47c828ffc1ff3e41f)] - Update: `snyk-snapshot.json`.\n- [[`511bba9c01`](https://github.com/sonarwhal/sonarwhal/commit/511bba9c0109b0cd6ea9348ad2d403000da2c726)] - New: Add type `Parser` and JavaScript parser (see also: [`#720`](https://github.com/sonarwhal/sonarwhal/issues/720)).\n\n"
+      html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/db6337b2206b710b70f93bf47c828ffc1ff3e41f\"><code>db6337b220</code></a>] - Update: <code>snyk-snapshot.json</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/511bba9c0109b0cd6ea9348ad2d403000da2c726\"><code>511bba9c01</code></a>] - New: Add type <code>Parser</code> and JavaScript parser (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/720\"><code>#720</code></a>).</li>\n</ul>\n"
+      details: 
+        db6337b2206b710b70f93bf47c828ffc1ff3e41f: 
+          associateCommitId: null
+          message: "Update: `snyk-snapshot.json`."
+        511bba9c0109b0cd6ea9348ad2d403000da2c726: 
+          associateCommitId: "720"
+          message: "New: Add type `Parser` and JavaScript parser."
+  0.20.1 (Decembe 12, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`559380f65e`](https://github.com/sonarwhal/sonarwhal/commit/559380f65e3edfa50d15896c66b3c8be48c7431c)] - Fix: Issue where tests of external rules couldn’t be run.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/559380f65e3edfa50d15896c66b3c8be48c7431c\"><code>559380f65e</code></a>] - Fix: Issue where tests of external rules couldn’t be run.</li>\n</ul>\n"
-      details:
-        559380f65e3edfa50d15896c66b3c8be48c7431c:
+      details: 
+        559380f65e3edfa50d15896c66b3c8be48c7431c: 
           associateCommitId: null
           message: "Fix: Issue where tests of external rules couldn’t be run."
-  0.20.0 (Decembe 12, 2017):
-    Bug fixes / Improvements:
+  0.20.0 (Decembe 12, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`0a9657642b`](https://github.com/sonarwhal/sonarwhal/commit/0a9657642b40321ce287bca7c0ac9e62d5f5c72b)] - Fix: Enable cache in `requester`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/0a9657642b40321ce287bca7c0ac9e62d5f5c72b\"><code>0a9657642b</code></a>] - Fix: Enable cache in <code>requester</code>.</li>\n</ul>\n"
-      details:
-        0a9657642b40321ce287bca7c0ac9e62d5f5c72b:
+      details: 
+        0a9657642b40321ce287bca7c0ac9e62d5f5c72b: 
           associateCommitId: null
           message: "Fix: Enable cache in `requester`."
-    New features:
+    New features: 
       raw: "- [[`69f2ece8b4`](https://github.com/sonarwhal/sonarwhal/commit/69f2ece8b40fe2eec057a3c013c0b24d31efa82d)] - New: Add `http-cache` rule (see also: [`#708`](https://github.com/sonarwhal/sonarwhal/issues/708)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/69f2ece8b40fe2eec057a3c013c0b24d31efa82d\"><code>69f2ece8b4</code></a>] - New: Add <code>http-cache</code> rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/708\"><code>#708</code></a>).</li>\n</ul>\n"
-      details:
-        69f2ece8b40fe2eec057a3c013c0b24d31efa82d:
+      details: 
+        69f2ece8b40fe2eec057a3c013c0b24d31efa82d: 
           associateCommitId: "708"
           message: "New: Add `http-cache` rule."
-  0.19.0 (Decembe 11, 2017):
-    New features:
+  0.19.0 (Decembe 11, 2017): 
+    New features: 
       raw: "- [[`d99100df54`](https://github.com/sonarwhal/sonarwhal/commit/d99100df542f1c34425ce631b00ed3a1f4d8da0a)] - New: Add better support for creating and running external rules (see also: [`#696`](https://github.com/sonarwhal/sonarwhal/issues/696)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/d99100df542f1c34425ce631b00ed3a1f4d8da0a\"><code>d99100df54</code></a>] - New: Add better support for creating and running external rules (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/696\"><code>#696</code></a>).</li>\n</ul>\n"
-      details:
-        d99100df542f1c34425ce631b00ed3a1f4d8da0a:
+      details: 
+        d99100df542f1c34425ce631b00ed3a1f4d8da0a: 
           associateCommitId: "696"
           message: "New: Add better support for creating and running external rules."
-  0.18.0 (Decembe 11, 2017):
-    Breaking Changes:
+  0.18.0 (Decembe 11, 2017): 
+    Breaking Changes: 
       raw: "- [[`ff472cc53d`](https://github.com/sonarwhal/sonarwhal/commit/ff472cc53ddc76d19230f5152d1c7733f6474cc9)] - Breaking: Fix parsing of file extensions (see also: [`#698`](https://github.com/sonarwhal/sonarwhal/issues/698)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/ff472cc53ddc76d19230f5152d1c7733f6474cc9\"><code>ff472cc53d</code></a>] - Breaking: Fix parsing of file extensions (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/698\"><code>#698</code></a>).</li>\n</ul>\n"
-      details:
-        ff472cc53ddc76d19230f5152d1c7733f6474cc9:
+      details: 
+        ff472cc53ddc76d19230f5152d1c7733f6474cc9: 
           associateCommitId: "698"
           message: "Breaking: Fix parsing of file extensions."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`222152093d`](https://github.com/sonarwhal/sonarwhal/commit/222152093d158f5bf6339ab2683d4f89b7172afe)] - Docs: Fix links to concepts.\n- [[`45af1045a3`](https://github.com/sonarwhal/sonarwhal/commit/45af1045a350c006da8efbbc7f1d206afd3d58d1)] - Docs: Make minor fixes and improvements.\n- [[`c7d4bada7b`](https://github.com/sonarwhal/sonarwhal/commit/c7d4bada7b3b69252e72b5a44f9e11707db9d37f)] - Docs: Reorganize `User Guide` (see also: [`#697`](https://github.com/sonarwhal/sonarwhal/issues/697)).\n- [[`3ef2793601`](https://github.com/sonarwhal/sonarwhal/commit/3ef27936011dde33953b8b9f08480eb9a37202c0)] - Docs: Fix rule name in `no-http-redirects.md` (see also: [`#686`](https://github.com/sonarwhal/sonarwhal/issues/686)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/222152093d158f5bf6339ab2683d4f89b7172afe\"><code>222152093d</code></a>] - Docs: Fix links to concepts.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/45af1045a350c006da8efbbc7f1d206afd3d58d1\"><code>45af1045a3</code></a>] - Docs: Make minor fixes and improvements.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/c7d4bada7b3b69252e72b5a44f9e11707db9d37f\"><code>c7d4bada7b</code></a>] - Docs: Reorganize <code>User Guide</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/697\"><code>#697</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/3ef27936011dde33953b8b9f08480eb9a37202c0\"><code>3ef2793601</code></a>] - Docs: Fix rule name in <code>no-http-redirects.md</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/686\"><code>#686</code></a>).</li>\n</ul>\n"
-      details:
-        222152093d158f5bf6339ab2683d4f89b7172afe:
+      details: 
+        222152093d158f5bf6339ab2683d4f89b7172afe: 
           associateCommitId: null
           message: "Docs: Fix links to concepts."
-        45af1045a350c006da8efbbc7f1d206afd3d58d1:
+        45af1045a350c006da8efbbc7f1d206afd3d58d1: 
           associateCommitId: null
           message: "Docs: Make minor fixes and improvements."
-        c7d4bada7b3b69252e72b5a44f9e11707db9d37f:
+        c7d4bada7b3b69252e72b5a44f9e11707db9d37f: 
           associateCommitId: "697"
           message: "Docs: Reorganize `User Guide`."
-        3ef27936011dde33953b8b9f08480eb9a37202c0:
+        3ef27936011dde33953b8b9f08480eb9a37202c0: 
           associateCommitId: "686"
           message: "Docs: Fix rule name in `no-http-redirects.md`."
-    New features:
+    New features: 
       raw: "- [[`72b76324d0`](https://github.com/sonarwhal/sonarwhal/commit/72b76324d02ce20715077bcded245248ba97f851)] - Update: `snyk-snapshot.json`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/72b76324d02ce20715077bcded245248ba97f851\"><code>72b76324d0</code></a>] - Update: <code>snyk-snapshot.json</code>.</li>\n</ul>\n"
-      details:
-        72b76324d02ce20715077bcded245248ba97f851:
+      details: 
+        72b76324d02ce20715077bcded245248ba97f851: 
           associateCommitId: null
           message: "Update: `snyk-snapshot.json`."
-  0.17.0 (November 29, 2017):
-    Bug fixes / Improvements:
+  0.17.0 (November 29, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`2a1623cbf0`](https://github.com/sonarwhal/sonarwhal/commit/2a1623cbf0dcc5cf3a8f445f43bf9a9cd0a6c13f)] - Docs: Add `edge` connector related information (see also: [`#671`](https://github.com/sonarwhal/sonarwhal/issues/671)).\n- [[`61874f64d0`](https://github.com/sonarwhal/sonarwhal/commit/61874f64d0016d9dd2f2e688a1d01096d71cbbb7)] - Docs: Mention performance aspects in `meta-viewport.md`.\n- [[`eec1298cd7`](https://github.com/sonarwhal/sonarwhal/commit/eec1298cd79e28a575bbc7912802b4f9d35c696e)] - Docs: Fix typo in `apple-touch-icons.md`.\n- [[`58e650d4c4`](https://github.com/sonarwhal/sonarwhal/commit/58e650d4c4e083b9a00ffde49ad9b3739336ea5e)] - Docs: Make minor improvements in `meta-viewport.md`.\n- [[`6ed5fb5a45`](https://github.com/sonarwhal/sonarwhal/commit/6ed5fb5a45dd99c4ea31cb26d8d31cd118cda48a)] - Docs: Rephrase `Public-Key-Pins` related information.\n- [[`b333372fc3`](https://github.com/sonarwhal/sonarwhal/commit/b333372fc375e9b1058bcbbf8f47827da1f7a85b)] - Docs: Fix rule name in `user-guide/rules/index.md`.\n- [[`c382d8771a`](https://github.com/sonarwhal/sonarwhal/commit/c382d8771adbac3afcab493b2c781ee6a26b7e45)] - Fix: Add missing `Category` import in the rule template.\n- [[`5d7203e5b0`](https://github.com/sonarwhal/sonarwhal/commit/5d7203e5b02fc26eb1947b32d041047acf24145c)] - Docs: Fix typo in `docs/user-guide/index.md`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/2a1623cbf0dcc5cf3a8f445f43bf9a9cd0a6c13f\"><code>2a1623cbf0</code></a>] - Docs: Add <code>edge</code> connector related information (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/671\"><code>#671</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/61874f64d0016d9dd2f2e688a1d01096d71cbbb7\"><code>61874f64d0</code></a>] - Docs: Mention performance aspects in <code>meta-viewport.md</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/eec1298cd79e28a575bbc7912802b4f9d35c696e\"><code>eec1298cd7</code></a>] - Docs: Fix typo in <code>apple-touch-icons.md</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/58e650d4c4e083b9a00ffde49ad9b3739336ea5e\"><code>58e650d4c4</code></a>] - Docs: Make minor improvements in <code>meta-viewport.md</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/6ed5fb5a45dd99c4ea31cb26d8d31cd118cda48a\"><code>6ed5fb5a45</code></a>] - Docs: Rephrase <code>Public-Key-Pins</code> related information.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/b333372fc375e9b1058bcbbf8f47827da1f7a85b\"><code>b333372fc3</code></a>] - Docs: Fix rule name in <code>user-guide/rules/index.md</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/c382d8771adbac3afcab493b2c781ee6a26b7e45\"><code>c382d8771a</code></a>] - Fix: Add missing <code>Category</code> import in the rule template.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/5d7203e5b02fc26eb1947b32d041047acf24145c\"><code>5d7203e5b0</code></a>] - Docs: Fix typo in <code>docs/user-guide/index.md</code>.</li>\n</ul>\n"
-      details:
-        2a1623cbf0dcc5cf3a8f445f43bf9a9cd0a6c13f:
+      details: 
+        2a1623cbf0dcc5cf3a8f445f43bf9a9cd0a6c13f: 
           associateCommitId: "671"
           message: "Docs: Add `edge` connector related information."
-        61874f64d0016d9dd2f2e688a1d01096d71cbbb7:
+        61874f64d0016d9dd2f2e688a1d01096d71cbbb7: 
           associateCommitId: null
           message: "Docs: Mention performance aspects in `meta-viewport.md`."
-        eec1298cd79e28a575bbc7912802b4f9d35c696e:
+        eec1298cd79e28a575bbc7912802b4f9d35c696e: 
           associateCommitId: null
           message: "Docs: Fix typo in `apple-touch-icons.md`."
-        58e650d4c4e083b9a00ffde49ad9b3739336ea5e:
+        58e650d4c4e083b9a00ffde49ad9b3739336ea5e: 
           associateCommitId: null
           message: "Docs: Make minor improvements in `meta-viewport.md`."
-        6ed5fb5a45dd99c4ea31cb26d8d31cd118cda48a:
+        6ed5fb5a45dd99c4ea31cb26d8d31cd118cda48a: 
           associateCommitId: null
           message: "Docs: Rephrase `Public-Key-Pins` related information."
-        b333372fc375e9b1058bcbbf8f47827da1f7a85b:
+        b333372fc375e9b1058bcbbf8f47827da1f7a85b: 
           associateCommitId: null
           message: "Docs: Fix rule name in `user-guide/rules/index.md`."
-        c382d8771adbac3afcab493b2c781ee6a26b7e45:
+        c382d8771adbac3afcab493b2c781ee6a26b7e45: 
           associateCommitId: null
           message: "Fix: Add missing `Category` import in the rule template."
-        5d7203e5b02fc26eb1947b32d041047acf24145c:
+        5d7203e5b02fc26eb1947b32d041047acf24145c: 
           associateCommitId: null
           message: "Docs: Fix typo in `docs/user-guide/index.md`."
-    New features:
+    New features: 
       raw: "- [[`6f28a78aa2`](https://github.com/sonarwhal/sonarwhal/commit/6f28a78aa2b66b1dfe22200bdfc59f22f15aaec6)] - Update: `snyk-snapshot.json`.\n- [[`6892a5ea7a`](https://github.com/sonarwhal/sonarwhal/commit/6892a5ea7a36b08e9ce372ac177aefc3fbabacc7)] - New: Add `connector-edge` as an `optionalDependency` (see also: [`#671`](https://github.com/sonarwhal/sonarwhal/issues/671)).\n- [[`f1ead8cddd`](https://github.com/sonarwhal/sonarwhal/commit/f1ead8cddd5e6bd4f39f7c4cbd37ac09e20e6c52)] - New: Add `defaultProfile` to Chrome launcher (see also: [`#628`](https://github.com/sonarwhal/sonarwhal/issues/628)).\n- [[`4a35e62834`](https://github.com/sonarwhal/sonarwhal/commit/4a35e62834f373ea0789c37882ef2784cd7263a5)] - New: Make connectors provide the `charset` and `media type` the response (see also: [`#676`](https://github.com/sonarwhal/sonarwhal/issues/676)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/6f28a78aa2b66b1dfe22200bdfc59f22f15aaec6\"><code>6f28a78aa2</code></a>] - Update: <code>snyk-snapshot.json</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/6892a5ea7a36b08e9ce372ac177aefc3fbabacc7\"><code>6892a5ea7a</code></a>] - New: Add <code>connector-edge</code> as an <code>optionalDependency</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/671\"><code>#671</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f1ead8cddd5e6bd4f39f7c4cbd37ac09e20e6c52\"><code>f1ead8cddd</code></a>] - New: Add <code>defaultProfile</code> to Chrome launcher (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/628\"><code>#628</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/4a35e62834f373ea0789c37882ef2784cd7263a5\"><code>4a35e62834</code></a>] - New: Make connectors provide the <code>charset</code> and <code>media type</code> the response (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/676\"><code>#676</code></a>).</li>\n</ul>\n"
-      details:
-        6f28a78aa2b66b1dfe22200bdfc59f22f15aaec6:
+      details: 
+        6f28a78aa2b66b1dfe22200bdfc59f22f15aaec6: 
           associateCommitId: null
           message: "Update: `snyk-snapshot.json`."
-        6892a5ea7a36b08e9ce372ac177aefc3fbabacc7:
+        6892a5ea7a36b08e9ce372ac177aefc3fbabacc7: 
           associateCommitId: "671"
           message: "New: Add `connector-edge` as an `optionalDependency`."
-        f1ead8cddd5e6bd4f39f7c4cbd37ac09e20e6c52:
+        f1ead8cddd5e6bd4f39f7c4cbd37ac09e20e6c52: 
           associateCommitId: "628"
           message: "New: Add `defaultProfile` to Chrome launcher."
-        4a35e62834f373ea0789c37882ef2784cd7263a5:
+        4a35e62834f373ea0789c37882ef2784cd7263a5: 
           associateCommitId: "676"
           message: "New: Make connectors provide the `charset` and `media type` the response."
-  0.16.0 (November 14, 2017):
-    Breaking Changes:
+  0.16.0 (November 14, 2017): 
+    Breaking Changes: 
       raw: "- [[`015d53e4b0`](https://github.com/sonarwhal/sonarwhal/commit/015d53e4b0a1a384e4929ebdbbce5d85a9fa6af4)] - Breaking: Rename `sonar` to `sonarwhal` everywhere (see also: [`#655`](https://github.com/sonarwhal/sonarwhal/issues/655)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/015d53e4b0a1a384e4929ebdbbce5d85a9fa6af4\"><code>015d53e4b0</code></a>] - Breaking: Rename <code>sonar</code> to <code>sonarwhal</code> everywhere (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/655\"><code>#655</code></a>).</li>\n</ul>\n"
-      details:
-        015d53e4b0a1a384e4929ebdbbce5d85a9fa6af4:
+      details: 
+        015d53e4b0a1a384e4929ebdbbce5d85a9fa6af4: 
           associateCommitId: "655"
           message: "Breaking: Rename `sonar` to `sonarwhal` everywhere."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`84b8eb3135`](https://github.com/sonarwhal/sonarwhal/commit/84b8eb31353f1b6aa90930d0381d255a2caae718)] - Docs: Update repository references.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/84b8eb31353f1b6aa90930d0381d255a2caae718\"><code>84b8eb3135</code></a>] - Docs: Update repository references.</li>\n</ul>\n"
-      details:
-        84b8eb31353f1b6aa90930d0381d255a2caae718:
+      details: 
+        84b8eb31353f1b6aa90930d0381d255a2caae718: 
           associateCommitId: null
           message: "Docs: Update repository references."
-  0.15.0 (November 14, 2017):
-    Breaking Changes:
+  0.15.0 (November 14, 2017): 
+    Breaking Changes: 
       raw: "- [[`b71b6f472a`](https://github.com/sonarwhal/sonarwhal/commit/b71b6f472adaafda50079d5cbc769e7f05324ac0)] - Breaking: Rename project from `sonar` to `sonarwhal`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/b71b6f472adaafda50079d5cbc769e7f05324ac0\"><code>b71b6f472a</code></a>] - Breaking: Rename project from <code>sonar</code> to <code>sonarwhal</code>.</li>\n</ul>\n"
-      details:
-        b71b6f472adaafda50079d5cbc769e7f05324ac0:
+      details: 
+        b71b6f472adaafda50079d5cbc769e7f05324ac0: 
           associateCommitId: null
           message: "Breaking: Rename project from `sonar` to `sonarwhal`."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`dd0a96ec98`](https://github.com/sonarwhal/sonarwhal/commit/dd0a96ec98ec81c7820f30180c99c1bebe932b50)] - Docs: Fix rule name in `image-optimization-cloudinary.md` (see also: [`#646`](https://github.com/sonarwhal/sonarwhal/issues/646)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/dd0a96ec98ec81c7820f30180c99c1bebe932b50\"><code>dd0a96ec98</code></a>] - Docs: Fix rule name in <code>image-optimization-cloudinary.md</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/646\"><code>#646</code></a>).</li>\n</ul>\n"
-      details:
-        dd0a96ec98ec81c7820f30180c99c1bebe932b50:
+      details: 
+        dd0a96ec98ec81c7820f30180c99c1bebe932b50: 
           associateCommitId: "646"
           message: "Docs: Fix rule name in `image-optimization-cloudinary.md`."
-    New features:
+    New features: 
       raw: "- [[`d6a1af9aa0`](https://github.com/sonarwhal/sonarwhal/commit/d6a1af9aa0bf9c8cc1cb84d27d77979c5aca1f4b)] - New: Add HPKP headers in `no-disallowed-headers` (see also: [`#631`](https://github.com/sonarwhal/sonarwhal/issues/631)).\n- [[`b6626897f8`](https://github.com/sonarwhal/sonarwhal/commit/b6626897f88ebcc7f8c9682f127cb002bc03f921)] - New: Add `no-http-redirects` rule (see also: [`#641`](https://github.com/sonarwhal/sonarwhal/issues/641)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/d6a1af9aa0bf9c8cc1cb84d27d77979c5aca1f4b\"><code>d6a1af9aa0</code></a>] - New: Add HPKP headers in <code>no-disallowed-headers</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/631\"><code>#631</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/b6626897f88ebcc7f8c9682f127cb002bc03f921\"><code>b6626897f8</code></a>] - New: Add <code>no-http-redirects</code> rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/641\"><code>#641</code></a>).</li>\n</ul>\n"
-      details:
-        d6a1af9aa0bf9c8cc1cb84d27d77979c5aca1f4b:
+      details: 
+        d6a1af9aa0bf9c8cc1cb84d27d77979c5aca1f4b: 
           associateCommitId: "631"
           message: "New: Add HPKP headers in `no-disallowed-headers`."
-        b6626897f88ebcc7f8c9682f127cb002bc03f921:
+        b6626897f88ebcc7f8c9682f127cb002bc03f921: 
           associateCommitId: "641"
           message: "New: Add `no-http-redirects` rule."
-  0.14.2 (November 10, 2017):
-    Bug fixes / Improvements:
+  0.14.2 (November 10, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`9736b13290`](https://github.com/sonarwhal/sonarwhal/commit/9736b132908fdde03bbfb5874fe754aff5fd7ee9)] - Fix: Improve third party service integration.\n- [[`e587e734b2`](https://github.com/sonarwhal/sonarwhal/commit/e587e734b209e1cbb6301028520b61a5a6e0b07c)] - Fix: Use `rulesTimeout` in `evaluate` (see also: [`#630`](https://github.com/sonarwhal/sonarwhal/issues/630)).\n- [[`7ad1c39e89`](https://github.com/sonarwhal/sonarwhal/commit/7ad1c39e89cdc60463adadfba2b78befe14f040a)] - Fix: Reduce `timeout` for requests (see also: [`#585`](https://github.com/sonarwhal/sonarwhal/issues/585)).\n- [[`ca02a33311`](https://github.com/sonarwhal/sonarwhal/commit/ca02a33311e9dc3c17721bd0b916337b5d3617a9)] - Fix: Handle timeout in `no-vulnerable-libraries` rule (see also: [`#627`](https://github.com/sonarwhal/sonarwhal/issues/627)).\n- [[`a8242fb7c3`](https://github.com/sonarwhal/sonarwhal/commit/a8242fb7c3d367093eac3b5b630580e09c935597)] - Docs: Fix typos.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/9736b132908fdde03bbfb5874fe754aff5fd7ee9\"><code>9736b13290</code></a>] - Fix: Improve third party service integration.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/e587e734b209e1cbb6301028520b61a5a6e0b07c\"><code>e587e734b2</code></a>] - Fix: Use <code>rulesTimeout</code> in <code>evaluate</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/630\"><code>#630</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/7ad1c39e89cdc60463adadfba2b78befe14f040a\"><code>7ad1c39e89</code></a>] - Fix: Reduce <code>timeout</code> for requests (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/585\"><code>#585</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/ca02a33311e9dc3c17721bd0b916337b5d3617a9\"><code>ca02a33311</code></a>] - Fix: Handle timeout in <code>no-vulnerable-libraries</code> rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/627\"><code>#627</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/a8242fb7c3d367093eac3b5b630580e09c935597\"><code>a8242fb7c3</code></a>] - Docs: Fix typos.</li>\n</ul>\n"
-      details:
-        9736b132908fdde03bbfb5874fe754aff5fd7ee9:
+      details: 
+        9736b132908fdde03bbfb5874fe754aff5fd7ee9: 
           associateCommitId: null
           message: "Fix: Improve third party service integration."
-        e587e734b209e1cbb6301028520b61a5a6e0b07c:
+        e587e734b209e1cbb6301028520b61a5a6e0b07c: 
           associateCommitId: "630"
           message: "Fix: Use `rulesTimeout` in `evaluate`."
-        7ad1c39e89cdc60463adadfba2b78befe14f040a:
+        7ad1c39e89cdc60463adadfba2b78befe14f040a: 
           associateCommitId: "585"
           message: "Fix: Reduce `timeout` for requests."
-        ca02a33311e9dc3c17721bd0b916337b5d3617a9:
+        ca02a33311e9dc3c17721bd0b916337b5d3617a9: 
           associateCommitId: "627"
           message: "Fix: Handle timeout in `no-vulnerable-libraries` rule."
-        a8242fb7c3d367093eac3b5b630580e09c935597:
+        a8242fb7c3d367093eac3b5b630580e09c935597: 
           associateCommitId: null
           message: "Docs: Fix typos."
-  0.14.1 (November 2, 2017):
-    Bug fixes / Improvements:
+  0.14.1 (November 2, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`4d13905075`](https://github.com/sonarwhal/sonarwhal/commit/4d139050755af4bf828727c4d699c85813162fb7)] - Fix: Make `Debugging Protocol Connector` related improvements (see also: [`#621`](https://github.com/sonarwhal/sonarwhal/issues/621)).\n- [[`f5650fba6f`](https://github.com/sonarwhal/sonarwhal/commit/f5650fba6f800b3e8b36ec2a325d24a3ecb5b14d)] - Fix: Force exit when `exitCode` is received (see also: [`#622`](https://github.com/sonarwhal/sonarwhal/issues/622)).\n- [[`8de8005af3`](https://github.com/sonarwhal/sonarwhal/commit/8de8005af30777e68f86fed7c19ecf348c19721c)] - Fix: Make `manifest-app-name` rule not fail for invalid content (see also: [`#610`](https://github.com/sonarwhal/sonarwhal/issues/610)).\n- [[`0c17774475`](https://github.com/sonarwhal/sonarwhal/commit/0c1777447521f466be4774fb997cd272b962b405)] - Docs: Update `Permission issue` section from `User Guide`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/4d139050755af4bf828727c4d699c85813162fb7\"><code>4d13905075</code></a>] - Fix: Make <code>Debugging Protocol Connector</code> related improvements (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/621\"><code>#621</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f5650fba6f800b3e8b36ec2a325d24a3ecb5b14d\"><code>f5650fba6f</code></a>] - Fix: Force exit when <code>exitCode</code> is received (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/622\"><code>#622</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/8de8005af30777e68f86fed7c19ecf348c19721c\"><code>8de8005af3</code></a>] - Fix: Make <code>manifest-app-name</code> rule not fail for invalid content (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/610\"><code>#610</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/0c1777447521f466be4774fb997cd272b962b405\"><code>0c17774475</code></a>] - Docs: Update <code>Permission issue</code> section from <code>User Guide</code>.</li>\n</ul>\n"
-      details:
-        4d139050755af4bf828727c4d699c85813162fb7:
+      details: 
+        4d139050755af4bf828727c4d699c85813162fb7: 
           associateCommitId: "621"
           message: "Fix: Make `Debugging Protocol Connector` related improvements."
-        f5650fba6f800b3e8b36ec2a325d24a3ecb5b14d:
+        f5650fba6f800b3e8b36ec2a325d24a3ecb5b14d: 
           associateCommitId: "622"
           message: "Fix: Force exit when `exitCode` is received."
-        8de8005af30777e68f86fed7c19ecf348c19721c:
+        8de8005af30777e68f86fed7c19ecf348c19721c: 
           associateCommitId: "610"
           message: "Fix: Make `manifest-app-name` rule not fail for invalid content."
-        0c1777447521f466be4774fb997cd272b962b405:
+        0c1777447521f466be4774fb997cd272b962b405: 
           associateCommitId: null
           message: "Docs: Update `Permission issue` section from `User Guide`."
-  0.14.0 (October 31, 2017):
-    Bug fixes / Improvements:
+  0.14.0 (October 31, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`f6136dc82e`](https://github.com/sonarwhal/sonarwhal/commit/f6136dc82ec925dc45bc973e1fc80574a0054873)] - Fix: Make `jsdom` not hang for invalid certificate (see also: [`#612`](https://github.com/sonarwhal/sonarwhal/issues/612), and [`#615`](https://github.com/sonarwhal/sonarwhal/issues/615)).\n- [[`c62ec505c5`](https://github.com/sonarwhal/sonarwhal/commit/c62ec505c5ea623f460c1d7b89e66aa634246f03)] - Docs: Make minor fixes in examples.\n- [[`85a432e9ff`](https://github.com/sonarwhal/sonarwhal/commit/85a432e9ff7a3bd33c37de094b28b507c7a66834)] - Docs: Fix broken links.\n- [[`400f5b5592`](https://github.com/sonarwhal/sonarwhal/commit/400f5b5592338b6b1f621c4fad21d47f2dadc14c)] - Docs: Rename `Developer Guide` to `Contributor Guide` (see also: [`#609`](https://github.com/sonarwhal/sonarwhal/issues/609)).\n- [[`924c0e7cef`](https://github.com/sonarwhal/sonarwhal/commit/924c0e7ceff3930cbe527a353ffa4312a71909d2)] - Docs: Fix link in `no-protocol-relative-urls.md`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f6136dc82ec925dc45bc973e1fc80574a0054873\"><code>f6136dc82e</code></a>] - Fix: Make <code>jsdom</code> not hang for invalid certificate (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/612\"><code>#612</code></a>, and <a href=\"https://github.com/sonarwhal/sonarwhal/issues/615\"><code>#615</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/c62ec505c5ea623f460c1d7b89e66aa634246f03\"><code>c62ec505c5</code></a>] - Docs: Make minor fixes in examples.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/85a432e9ff7a3bd33c37de094b28b507c7a66834\"><code>85a432e9ff</code></a>] - Docs: Fix broken links.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/400f5b5592338b6b1f621c4fad21d47f2dadc14c\"><code>400f5b5592</code></a>] - Docs: Rename <code>Developer Guide</code> to <code>Contributor Guide</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/609\"><code>#609</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/924c0e7ceff3930cbe527a353ffa4312a71909d2\"><code>924c0e7cef</code></a>] - Docs: Fix link in <code>no-protocol-relative-urls.md</code>.</li>\n</ul>\n"
-      details:
-        f6136dc82ec925dc45bc973e1fc80574a0054873:
+      details: 
+        f6136dc82ec925dc45bc973e1fc80574a0054873: 
           associateCommitId: null
           message: "Fix: Make `jsdom` not hang for invalid certificate (see also: [`#612`](https://github.com/sonarwhal/sonarwhal/issues/612), and [`#615`](https://github.com/sonarwhal/sonarwhal/issues/615))."
-        c62ec505c5ea623f460c1d7b89e66aa634246f03:
+        c62ec505c5ea623f460c1d7b89e66aa634246f03: 
           associateCommitId: null
           message: "Docs: Make minor fixes in examples."
-        85a432e9ff7a3bd33c37de094b28b507c7a66834:
+        85a432e9ff7a3bd33c37de094b28b507c7a66834: 
           associateCommitId: null
           message: "Docs: Fix broken links."
-        400f5b5592338b6b1f621c4fad21d47f2dadc14c:
+        400f5b5592338b6b1f621c4fad21d47f2dadc14c: 
           associateCommitId: "609"
           message: "Docs: Rename `Developer Guide` to `Contributor Guide`."
-        924c0e7ceff3930cbe527a353ffa4312a71909d2:
+        924c0e7ceff3930cbe527a353ffa4312a71909d2: 
           associateCommitId: null
           message: "Docs: Fix link in `no-protocol-relative-urls.md`."
-    New features:
+    New features: 
       raw: "- [[`a1833cd08d`](https://github.com/sonarwhal/sonarwhal/commit/a1833cd08d37f0195c93da2d85e55be48f77ab72)] - Update: `snyk-snapshot.json`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/a1833cd08d37f0195c93da2d85e55be48f77ab72\"><code>a1833cd08d</code></a>] - Update: <code>snyk-snapshot.json</code>.</li>\n</ul>\n"
-      details:
-        a1833cd08d37f0195c93da2d85e55be48f77ab72:
+      details: 
+        a1833cd08d37f0195c93da2d85e55be48f77ab72: 
           associateCommitId: null
           message: "Update: `snyk-snapshot.json`."
-  0.13.0 (October 27, 2017):
-    Breaking Changes:
+  0.13.0 (October 27, 2017): 
+    Breaking Changes: 
       raw: "- [[`255bb7bc0c`](https://github.com/sonarwhal/sonarwhal/commit/255bb7bc0c5429475619a51926cedf709e7c0c68)] - Breaking: Change definition of `ignoredUrls`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/255bb7bc0c5429475619a51926cedf709e7c0c68\"><code>255bb7bc0c</code></a>] - Breaking: Change definition of <code>ignoredUrls</code>.</li>\n</ul>\n"
-      details:
-        255bb7bc0c5429475619a51926cedf709e7c0c68:
+      details: 
+        255bb7bc0c5429475619a51926cedf709e7c0c68: 
           associateCommitId: null
           message: "Breaking: Change definition of `ignoredUrls`."
-  0.12.3 (October 23, 2017):
-    Bug fixes / Improvements:
+  0.12.3 (October 23, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`3f03824695`](https://github.com/sonarwhal/sonarwhal/commit/3f03824695d1553dfe4d5334632a9ea28e694d9c)] - Fix: Issue with Cloudinary and error handling.\n- [[`1e131ddb28`](https://github.com/sonarwhal/sonarwhal/commit/1e131ddb2828d1718b1c2c756d3cda7c38f4ba0b)] - Docs: Fix link in `docs/about/FAQ.md` (see also: [`#592`](https://github.com/sonarwhal/sonarwhal/issues/592)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/3f03824695d1553dfe4d5334632a9ea28e694d9c\"><code>3f03824695</code></a>] - Fix: Issue with Cloudinary and error handling.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/1e131ddb2828d1718b1c2c756d3cda7c38f4ba0b\"><code>1e131ddb28</code></a>] - Docs: Fix link in <code>docs/about/FAQ.md</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/592\"><code>#592</code></a>).</li>\n</ul>\n"
-      details:
-        3f03824695d1553dfe4d5334632a9ea28e694d9c:
+      details: 
+        3f03824695d1553dfe4d5334632a9ea28e694d9c: 
           associateCommitId: null
           message: "Fix: Issue with Cloudinary and error handling."
-        1e131ddb2828d1718b1c2c756d3cda7c38f4ba0b:
+        1e131ddb2828d1718b1c2c756d3cda7c38f4ba0b: 
           associateCommitId: "592"
           message: "Docs: Fix link in `docs/about/FAQ.md`."
-  0.12.2 (October 20, 2017):
-    Bug fixes / Improvements:
+  0.12.2 (October 20, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`4ed7cf2aa9`](https://github.com/sonarwhal/sonarwhal/commit/4ed7cf2aa9092e15576287226271dfa9b8e82979)] - Fix: Issue in Cloudinary with invalid images.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/4ed7cf2aa9092e15576287226271dfa9b8e82979\"><code>4ed7cf2aa9</code></a>] - Fix: Issue in Cloudinary with invalid images.</li>\n</ul>\n"
-      details:
-        4ed7cf2aa9092e15576287226271dfa9b8e82979:
+      details: 
+        4ed7cf2aa9092e15576287226271dfa9b8e82979: 
           associateCommitId: null
           message: "Fix: Issue in Cloudinary with invalid images."
-  0.12.1 (October 20, 2017):
-    Bug fixes / Improvements:
+  0.12.1 (October 20, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`0e141f33ce`](https://github.com/sonarwhal/sonarwhal/commit/0e141f33ce7d159e22c7e33aa15867e03eff025a)] - Fix: Cloudinary authentication issue.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/0e141f33ce7d159e22c7e33aa15867e03eff025a\"><code>0e141f33ce</code></a>] - Fix: Cloudinary authentication issue.</li>\n</ul>\n"
-      details:
-        0e141f33ce7d159e22c7e33aa15867e03eff025a:
+      details: 
+        0e141f33ce7d159e22c7e33aa15867e03eff025a: 
           associateCommitId: null
           message: "Fix: Cloudinary authentication issue."
-  0.12.0 (October 19, 2017):
-    Bug fixes / Improvements:
+  0.12.0 (October 19, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`92c815ca57`](https://github.com/sonarwhal/sonarwhal/commit/92c815ca57cf791e93a36b68c602588a4f1b2cc2)] - Fix: Improve `test-server` and `debugging-protocol` requests logic (see also: [`#582`](https://github.com/sonarwhal/sonarwhal/issues/582)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/92c815ca57cf791e93a36b68c602588a4f1b2cc2\"><code>92c815ca57</code></a>] - Fix: Improve <code>test-server</code> and <code>debugging-protocol</code> requests logic (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/582\"><code>#582</code></a>).</li>\n</ul>\n"
-      details:
-        92c815ca57cf791e93a36b68c602588a4f1b2cc2:
+      details: 
+        92c815ca57cf791e93a36b68c602588a4f1b2cc2: 
           associateCommitId: "582"
           message: "Fix: Improve `test-server` and `debugging-protocol` requests logic."
-    New features:
+    New features: 
       raw: "- [[`8a7e1ea5f7`](https://github.com/sonarwhal/sonarwhal/commit/8a7e1ea5f7bbe5dc21db412a79aec487354d986b)] - New: Add image optimization rule using Cloudinary's service (see also: [`#575`](https://github.com/sonarwhal/sonarwhal/issues/575)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/8a7e1ea5f7bbe5dc21db412a79aec487354d986b\"><code>8a7e1ea5f7</code></a>] - New: Add image optimization rule using Cloudinary’s service (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/575\"><code>#575</code></a>).</li>\n</ul>\n"
-      details:
-        8a7e1ea5f7bbe5dc21db412a79aec487354d986b:
+      details: 
+        8a7e1ea5f7bbe5dc21db412a79aec487354d986b: 
           associateCommitId: "575"
           message: "New: Add image optimization rule using Cloudinary's service."
-  0.11.0 (October 19, 2017):
-    Breaking Changes:
+  0.11.0 (October 19, 2017): 
+    Breaking Changes: 
       raw: "- [[`f794bc8f36`](https://github.com/sonarwhal/sonarwhal/commit/f794bc8f362c970d0cc398546e7bf614a4759661)] - Breaking: Require `text/javascript` as the media type for JavaScript files (see also: [`#568`](https://github.com/sonarwhal/sonarwhal/issues/568)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f794bc8f362c970d0cc398546e7bf614a4759661\"><code>f794bc8f36</code></a>] - Breaking: Require <code>text/javascript</code> as the media type for JavaScript files (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/568\"><code>#568</code></a>).</li>\n</ul>\n"
-      details:
-        f794bc8f362c970d0cc398546e7bf614a4759661:
+      details: 
+        f794bc8f362c970d0cc398546e7bf614a4759661: 
           associateCommitId: "568"
           message: "Breaking: Require `text/javascript` as the media type for JavaScript files."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`55b2190c35`](https://github.com/sonarwhal/sonarwhal/commit/55b2190c354fde5ed581c4d00a9f5e235ff4ae53)] - Docs: Update FAQ with information about the online scanner and the project history (see also: [`#580`](https://github.com/sonarwhal/sonarwhal/issues/580)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/55b2190c354fde5ed581c4d00a9f5e235ff4ae53\"><code>55b2190c35</code></a>] - Docs: Update FAQ with information about the online scanner and the project history (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/580\"><code>#580</code></a>).</li>\n</ul>\n"
-      details:
-        55b2190c354fde5ed581c4d00a9f5e235ff4ae53:
+      details: 
+        55b2190c354fde5ed581c4d00a9f5e235ff4ae53: 
           associateCommitId: "580"
           message: "Docs: Update FAQ with information about the online scanner and the project history."
-  0.10.2 (October 5, 2017):
-    Bug fixes / Improvements:
+  0.10.2 (October 5, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`8da2e2da12`](https://github.com/sonarwhal/sonarwhal/commit/8da2e2da1296098146095849d59bdf7b56eabc18)] - Fix: Redo last release in order to fix the `node\\r` related issue (see also: [`#564`](https://github.com/sonarwhal/sonarwhal/issues/564)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/8da2e2da1296098146095849d59bdf7b56eabc18\"><code>8da2e2da12</code></a>] - Fix: Redo last release in order to fix the <code>node\\r</code> related issue (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/564\"><code>#564</code></a>).</li>\n</ul>\n"
-      details:
-        8da2e2da1296098146095849d59bdf7b56eabc18:
+      details: 
+        8da2e2da1296098146095849d59bdf7b56eabc18: 
           associateCommitId: "564"
           message: "Fix: Redo last release in order to fix the `node\\r` related issue."
-  0.10.1 (October 4, 2017):
-    Bug fixes / Improvements:
+  0.10.1 (October 4, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`2918e04ce7`](https://github.com/sonarwhal/sonarwhal/commit/2918e04ce7a21381cacee03ffe373a3bc276bb54)] - Fix: Generate correctly the `.sonarrc` file if not found (see also: [`#562`](https://github.com/sonarwhal/sonarwhal/issues/562)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/2918e04ce7a21381cacee03ffe373a3bc276bb54\"><code>2918e04ce7</code></a>] - Fix: Generate correctly the <code>.sonarrc</code> file if not found (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/562\"><code>#562</code></a>).</li>\n</ul>\n"
-      details:
-        2918e04ce7a21381cacee03ffe373a3bc276bb54:
+      details: 
+        2918e04ce7a21381cacee03ffe373a3bc276bb54: 
           associateCommitId: "562"
           message: "Fix: Generate correctly the `.sonarrc` file if not found."
-  0.10.0 (October 3, 2017):
-    Bug fixes / Improvements:
+  0.10.0 (October 3, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`f5c0218bdf`](https://github.com/sonarwhal/sonarwhal/commit/f5c0218bdf5ef85921f032edece6c903abda9d07)] - Fix: Update `new-core-rule` templates (see also: [`#551`](https://github.com/sonarwhal/sonarwhal/issues/551)).\n- [[`f2e500d16b`](https://github.com/sonarwhal/sonarwhal/commit/f2e500d16b4ff5c690e84b67811ec7dd319a675c)] - Fix: New version notifications handling (see also: [`#507`](https://github.com/sonarwhal/sonarwhal/issues/507)).\n- [[`bb17fbbc2b`](https://github.com/sonarwhal/sonarwhal/commit/bb17fbbc2b9e92fc6e5bf705da1dbf75da828971)] - Fix: Don't show help after analyzing site (see also: [`#553`](https://github.com/sonarwhal/sonarwhal/issues/553)).\n- [[`f6dae7cfe2`](https://github.com/sonarwhal/sonarwhal/commit/f6dae7cfe21068b56f6e7d9b9a9156943980545c)] - Fix: Property name for new tab url.\n- [[`718f7198ac`](https://github.com/sonarwhal/sonarwhal/commit/718f7198ac1bf0624fb9a13a3bc71445942c9f40)] - Fix: Make tests more reliable and faster (see also: [`#502`](https://github.com/sonarwhal/sonarwhal/issues/502)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f5c0218bdf5ef85921f032edece6c903abda9d07\"><code>f5c0218bdf</code></a>] - Fix: Update <code>new-core-rule</code> templates (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/551\"><code>#551</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f2e500d16b4ff5c690e84b67811ec7dd319a675c\"><code>f2e500d16b</code></a>] - Fix: New version notifications handling (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/507\"><code>#507</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/bb17fbbc2b9e92fc6e5bf705da1dbf75da828971\"><code>bb17fbbc2b</code></a>] - Fix: Don’t show help after analyzing site (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/553\"><code>#553</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f6dae7cfe21068b56f6e7d9b9a9156943980545c\"><code>f6dae7cfe2</code></a>] - Fix: Property name for new tab url.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/718f7198ac1bf0624fb9a13a3bc71445942c9f40\"><code>718f7198ac</code></a>] - Fix: Make tests more reliable and faster (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/502\"><code>#502</code></a>).</li>\n</ul>\n"
-      details:
-        f5c0218bdf5ef85921f032edece6c903abda9d07:
+      details: 
+        f5c0218bdf5ef85921f032edece6c903abda9d07: 
           associateCommitId: "551"
           message: "Fix: Update `new-core-rule` templates."
-        f2e500d16b4ff5c690e84b67811ec7dd319a675c:
+        f2e500d16b4ff5c690e84b67811ec7dd319a675c: 
           associateCommitId: "507"
           message: "Fix: New version notifications handling."
-        bb17fbbc2b9e92fc6e5bf705da1dbf75da828971:
+        bb17fbbc2b9e92fc6e5bf705da1dbf75da828971: 
           associateCommitId: "553"
           message: "Fix: Don't show help after analyzing site."
-        f6dae7cfe21068b56f6e7d9b9a9156943980545c:
+        f6dae7cfe21068b56f6e7d9b9a9156943980545c: 
           associateCommitId: null
           message: "Fix: Property name for new tab url."
-        718f7198ac1bf0624fb9a13a3bc71445942c9f40:
+        718f7198ac1bf0624fb9a13a3bc71445942c9f40: 
           associateCommitId: "502"
           message: "Fix: Make tests more reliable and faster."
-    New features:
+    New features: 
       raw: "- [[`62a52a66a4`](https://github.com/sonarwhal/sonarwhal/commit/62a52a66a409adc106dc0f7100b4a38253a95f82)] - New: Make viewport rule work with `viewport-fit` (see also: [`#557`](https://github.com/sonarwhal/sonarwhal/issues/557)).\n- [[`01fbe5ee9c`](https://github.com/sonarwhal/sonarwhal/commit/01fbe5ee9cc2d8c9e93f61ddfbfc47cd41e9faae)] - New: Add `amp-validator` rule (see also: [`#545`](https://github.com/sonarwhal/sonarwhal/issues/545)).\n- [[`67553dce6c`](https://github.com/sonarwhal/sonarwhal/commit/67553dce6c0c390b561cca0d44aa0bf8a07e7515)] - New: Add option to create external rule (see also: [`#528`](https://github.com/sonarwhal/sonarwhal/issues/528)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/62a52a66a409adc106dc0f7100b4a38253a95f82\"><code>62a52a66a4</code></a>] - New: Make viewport rule work with <code>viewport-fit</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/557\"><code>#557</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/01fbe5ee9cc2d8c9e93f61ddfbfc47cd41e9faae\"><code>01fbe5ee9c</code></a>] - New: Add <code>amp-validator</code> rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/545\"><code>#545</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/67553dce6c0c390b561cca0d44aa0bf8a07e7515\"><code>67553dce6c</code></a>] - New: Add option to create external rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/528\"><code>#528</code></a>).</li>\n</ul>\n"
-      details:
-        62a52a66a409adc106dc0f7100b4a38253a95f82:
+      details: 
+        62a52a66a409adc106dc0f7100b4a38253a95f82: 
           associateCommitId: "557"
           message: "New: Make viewport rule work with `viewport-fit`."
-        01fbe5ee9cc2d8c9e93f61ddfbfc47cd41e9faae:
+        01fbe5ee9cc2d8c9e93f61ddfbfc47cd41e9faae: 
           associateCommitId: "545"
           message: "New: Add `amp-validator` rule."
-        67553dce6c0c390b561cca0d44aa0bf8a07e7515:
+        67553dce6c0c390b561cca0d44aa0bf8a07e7515: 
           associateCommitId: "528"
           message: "New: Add option to create external rule."
-  0.9.0 (September 27, 2017):
-    Breaking Changes:
+  0.9.0 (September 27, 2017): 
+    Breaking Changes: 
       raw: "- [[`e585daa5d5`](https://github.com/sonarwhal/sonarwhal/commit/e585daa5d51db030edc259443705d938d7ff66a6)] - Breaking: Make `rawResponse` a `Promise<Buffer>` (see also: [`#164`](https://github.com/sonarwhal/sonarwhal/issues/164)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/e585daa5d51db030edc259443705d938d7ff66a6\"><code>e585daa5d5</code></a>] - Breaking: Make <code>rawResponse</code> a <code>Promise&lt;Buffer&gt;</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/164\"><code>#164</code></a>).</li>\n</ul>\n"
-      details:
-        e585daa5d51db030edc259443705d938d7ff66a6:
+      details: 
+        e585daa5d51db030edc259443705d938d7ff66a6: 
           associateCommitId: "164"
           message: "Breaking: Make `rawResponse` a `Promise<Buffer>`."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`0cfb1bb49c`](https://github.com/sonarwhal/sonarwhal/commit/0cfb1bb49c847eb4d5ed54691dbb88cb796694bf)] - Fix: Create new rule only in `sonar`'s root folder (see also: [`#527`](https://github.com/sonarwhal/sonarwhal/issues/527)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/0cfb1bb49c847eb4d5ed54691dbb88cb796694bf\"><code>0cfb1bb49c</code></a>] - Fix: Create new rule only in <code>sonar</code>‘s root folder (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/527\"><code>#527</code></a>).</li>\n</ul>\n"
-      details:
-        0cfb1bb49c847eb4d5ed54691dbb88cb796694bf:
+      details: 
+        0cfb1bb49c847eb4d5ed54691dbb88cb796694bf: 
           associateCommitId: "527"
           message: "Fix: Create new rule only in `sonar`'s root folder."
-    New features:
+    New features: 
       raw: "- [[`67553dce6c`](https://github.com/sonarwhal/sonarwhal/commit/67553dce6c0c390b561cca0d44aa0bf8a07e7515)] - New: Add option to create external rule (see also: [`#528`](https://github.com/sonarwhal/sonarwhal/issues/528)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/67553dce6c0c390b561cca0d44aa0bf8a07e7515\"><code>67553dce6c</code></a>] - New: Add option to create external rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/528\"><code>#528</code></a>).</li>\n</ul>\n"
-      details:
-        67553dce6c0c390b561cca0d44aa0bf8a07e7515:
+      details: 
+        67553dce6c0c390b561cca0d44aa0bf8a07e7515: 
           associateCommitId: "528"
           message: "New: Add option to create external rule."
-  0.8.1 (September 22, 2017):
-    Bug fixes / Improvements:
+  0.8.1 (September 22, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`41a56bef2f`](https://github.com/sonarwhal/sonarwhal/commit/41a56bef2ffd21b3612e3c0b637754b95629d242)] - Fix: Add `tests/helpers` to `npm` package (see also: [`#532`](https://github.com/sonarwhal/sonarwhal/issues/532)).\n- [[`8207e0fb3b`](https://github.com/sonarwhal/sonarwhal/commit/8207e0fb3b4dc7fa180e6b057babd78252d560a8)] - Docs: Add `connector` support information (see also: [`#523`](https://github.com/sonarwhal/sonarwhal/issues/523)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/41a56bef2ffd21b3612e3c0b637754b95629d242\"><code>41a56bef2f</code></a>] - Fix: Add <code>tests/helpers</code> to <code>npm</code> package (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/532\"><code>#532</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/8207e0fb3b4dc7fa180e6b057babd78252d560a8\"><code>8207e0fb3b</code></a>] - Docs: Add <code>connector</code> support information (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/523\"><code>#523</code></a>).</li>\n</ul>\n"
-      details:
-        41a56bef2ffd21b3612e3c0b637754b95629d242:
+      details: 
+        41a56bef2ffd21b3612e3c0b637754b95629d242: 
           associateCommitId: "532"
           message: "Fix: Add `tests/helpers` to `npm` package."
-        8207e0fb3b4dc7fa180e6b057babd78252d560a8:
+        8207e0fb3b4dc7fa180e6b057babd78252d560a8: 
           associateCommitId: "523"
           message: "Docs: Add `connector` support information."
-  0.8.0 (September 20, 2017):
-    Bug fixes / Improvements:
+  0.8.0 (September 20, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`ff45cb6497`](https://github.com/sonarwhal/sonarwhal/commit/ff45cb649737eaad438d54934d85bea556fdf1c5)] - Fix: Improve documentation for connectors (see also: [`#500`](https://github.com/sonarwhal/sonarwhal/issues/500)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/ff45cb649737eaad438d54934d85bea556fdf1c5\"><code>ff45cb6497</code></a>] - Fix: Improve documentation for connectors (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/500\"><code>#500</code></a>).</li>\n</ul>\n"
-      details:
-        ff45cb649737eaad438d54934d85bea556fdf1c5:
+      details: 
+        ff45cb649737eaad438d54934d85bea556fdf1c5: 
           associateCommitId: "500"
           message: "Fix: Improve documentation for connectors."
-    New features:
+    New features: 
       raw: "- [[`84561d847f`](https://github.com/sonarwhal/sonarwhal/commit/84561d847f598158d571ddef6a8f5f8201592254)] - New: Add `chrome-launcher` support for Windows Subsystem for Linux (WSL) (see also: [`GoogleChrome/chrome-launcher#26`](https://github.com/GoogleChrome/chrome-launcher/issues/26)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/84561d847f598158d571ddef6a8f5f8201592254\"><code>84561d847f</code></a>] - New: Add <code>chrome-launcher</code> support for Windows Subsystem for Linux (WSL) (see also: <a href=\"https://github.com/GoogleChrome/chrome-launcher/issues/26\"><code>GoogleChrome/chrome-launcher#26</code></a>).</li>\n</ul>\n"
-      details:
-        84561d847f598158d571ddef6a8f5f8201592254:
+      details: 
+        84561d847f598158d571ddef6a8f5f8201592254: 
           associateCommitId: null
           message: "New: Add `chrome-launcher` support for Windows Subsystem for Linux (WSL) (see also: [`GoogleChrome/chrome-launcher#26`](https://github.com/GoogleChrome/chrome-launcher/issues/26))."
-  0.7.0 (September 15, 2017):
-    Breaking Changes:
+  0.7.0 (September 15, 2017): 
+    Breaking Changes: 
       raw: "- [[`75b936b710`](https://github.com/sonarwhal/sonarwhal/commit/75b936b710505160fda7200034e4aada13ce1688)] - Breaking: Add support for multiple formatters (see also: [`#322`](https://github.com/sonarwhal/sonarwhal/issues/322)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/75b936b710505160fda7200034e4aada13ce1688\"><code>75b936b710</code></a>] - Breaking: Add support for multiple formatters (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/322\"><code>#322</code></a>).</li>\n</ul>\n"
-      details:
-        75b936b710505160fda7200034e4aada13ce1688:
+      details: 
+        75b936b710505160fda7200034e4aada13ce1688: 
           associateCommitId: "322"
           message: "Breaking: Add support for multiple formatters."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`f3074a3cbb`](https://github.com/sonarwhal/sonarwhal/commit/f3074a3cbbb5f5508d87836e042037dddcee63f7)] - Fix: Make `apple-touch-icons` rule not break for invalid or corrupt images (see also: [`#515`](https://github.com/sonarwhal/sonarwhal/issues/515)).\n- [[`b2e30d6d1f`](https://github.com/sonarwhal/sonarwhal/commit/b2e30d6d1fd0f0a3f00a80fd04420d662ca6747a)] - Docs: Add `--engine-strict` to install instructions (see also: [`#511`](https://github.com/sonarwhal/sonarwhal/issues/511)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f3074a3cbbb5f5508d87836e042037dddcee63f7\"><code>f3074a3cbb</code></a>] - Fix: Make <code>apple-touch-icons</code> rule not break for invalid or corrupt images (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/515\"><code>#515</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/b2e30d6d1fd0f0a3f00a80fd04420d662ca6747a\"><code>b2e30d6d1f</code></a>] - Docs: Add <code>--engine-strict</code> to install instructions (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/511\"><code>#511</code></a>).</li>\n</ul>\n"
-      details:
-        f3074a3cbbb5f5508d87836e042037dddcee63f7:
+      details: 
+        f3074a3cbbb5f5508d87836e042037dddcee63f7: 
           associateCommitId: "515"
           message: "Fix: Make `apple-touch-icons` rule not break for invalid or corrupt images."
-        b2e30d6d1fd0f0a3f00a80fd04420d662ca6747a:
+        b2e30d6d1fd0f0a3f00a80fd04420d662ca6747a: 
           associateCommitId: "511"
           message: "Docs: Add `--engine-strict` to install instructions."
-  0.6.3 (September 11, 2017):
-    Bug fixes / Improvements:
+  0.6.3 (September 11, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`fcafcc9add`](https://github.com/sonarwhal/sonarwhal/commit/fcafcc9add5baac6fc006708ebc15ed35cec6cea)] - Fix: Make `npm` package not include `devDependencies`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/fcafcc9add5baac6fc006708ebc15ed35cec6cea\"><code>fcafcc9add</code></a>] - Fix: Make <code>npm</code> package not include <code>devDependencies</code>.</li>\n</ul>\n"
-      details:
-        fcafcc9add5baac6fc006708ebc15ed35cec6cea:
+      details: 
+        fcafcc9add5baac6fc006708ebc15ed35cec6cea: 
           associateCommitId: null
           message: "Fix: Make `npm` package not include `devDependencies`."
-  0.6.2 (September 8, 2017):
-    Bug fixes / Improvements:
+  0.6.2 (September 8, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`bedc9644dc`](https://github.com/sonarwhal/sonarwhal/commit/bedc9644dcd844455140da8fb2572716c8135fec)] - Fix: Make `npm` package actually include `npm-shrinkwrap.json` file (see also: [`#481`](https://github.com/sonarwhal/sonarwhal/issues/481)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/bedc9644dcd844455140da8fb2572716c8135fec\"><code>bedc9644dc</code></a>] - Fix: Make <code>npm</code> package actually include <code>npm-shrinkwrap.json</code> file (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/481\"><code>#481</code></a>).</li>\n</ul>\n"
-      details:
-        bedc9644dcd844455140da8fb2572716c8135fec:
+      details: 
+        bedc9644dcd844455140da8fb2572716c8135fec: 
           associateCommitId: "481"
           message: "Fix: Make `npm` package actually include `npm-shrinkwrap.json` file."
-  0.6.1 (September 8, 2017):
-    Bug fixes / Improvements:
+  0.6.1 (September 8, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`0d7b4038bf`](https://github.com/sonarwhal/sonarwhal/commit/0d7b4038bfd07987c969253429c77d4acc997eab)] - Fix: Add `npm-shrinkwrap.json` to the `npm` package (see also: [`#481`](https://github.com/sonarwhal/sonarwhal/issues/481)).\n- [[`3300798874`](https://github.com/sonarwhal/sonarwhal/commit/3300798874163866fa38da6a8295ad10033878a3)] - Fix: SemVer related issue with `no-vulnerable-javascript-libraries` rule (see also: [`#504`](https://github.com/sonarwhal/sonarwhal/issues/504)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/0d7b4038bfd07987c969253429c77d4acc997eab\"><code>0d7b4038bf</code></a>] - Fix: Add <code>npm-shrinkwrap.json</code> to the <code>npm</code> package (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/481\"><code>#481</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/3300798874163866fa38da6a8295ad10033878a3\"><code>3300798874</code></a>] - Fix: SemVer related issue with <code>no-vulnerable-javascript-libraries</code> rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/504\"><code>#504</code></a>).</li>\n</ul>\n"
-      details:
-        0d7b4038bfd07987c969253429c77d4acc997eab:
+      details: 
+        0d7b4038bfd07987c969253429c77d4acc997eab: 
           associateCommitId: "481"
           message: "Fix: Add `npm-shrinkwrap.json` to the `npm` package."
-        3300798874163866fa38da6a8295ad10033878a3:
+        3300798874163866fa38da6a8295ad10033878a3: 
           associateCommitId: "504"
           message: "Fix: SemVer related issue with `no-vulnerable-javascript-libraries` rule."
-  0.6.0 (September 8, 2017):
-    Bug fixes / Improvements:
+  0.6.0 (September 8, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`32dcb344bd`](https://github.com/sonarwhal/sonarwhal/commit/32dcb344bd36a2e5aa94ae2e3589e0d9cb5ad72c)] - Fix: Make improvements to `chrome` connector (see also: [`#387`](https://github.com/sonarwhal/sonarwhal/issues/387), and [`#471`](https://github.com/sonarwhal/sonarwhal/issues/471)).\n- [[`97bc6ea26b`](https://github.com/sonarwhal/sonarwhal/commit/97bc6ea26b61b32c98499e4754a66ad48ce21511)] - Fix: Make `fetchContent` return raw data in chrome (see also: [`#495`](https://github.com/sonarwhal/sonarwhal/issues/495)).\n- [[`a5b9951d2d`](https://github.com/sonarwhal/sonarwhal/commit/a5b9951d2d2a83d047c22f9b08252974666e1355)] - Fix: Spinner getting stuck issue (see also: [`#485`](https://github.com/sonarwhal/sonarwhal/issues/485)).\n- [[`481961c571`](https://github.com/sonarwhal/sonarwhal/commit/481961c571059137a780aa3d5243ab4d232a016d)] - Docs: Make rule code examples more consistent.\n- [[`e2af8a87cf`](https://github.com/sonarwhal/sonarwhal/commit/e2af8a87cf2a3a1fb892006853b98a423fd7dff6)] - Fix: Infinite hop calculation when there's a cycle (see also: [`#486`](https://github.com/sonarwhal/sonarwhal/issues/486)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/32dcb344bd36a2e5aa94ae2e3589e0d9cb5ad72c\"><code>32dcb344bd</code></a>] - Fix: Make improvements to <code>chrome</code> connector (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/387\"><code>#387</code></a>, and <a href=\"https://github.com/sonarwhal/sonarwhal/issues/471\"><code>#471</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/97bc6ea26b61b32c98499e4754a66ad48ce21511\"><code>97bc6ea26b</code></a>] - Fix: Make <code>fetchContent</code> return raw data in chrome (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/495\"><code>#495</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/a5b9951d2d2a83d047c22f9b08252974666e1355\"><code>a5b9951d2d</code></a>] - Fix: Spinner getting stuck issue (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/485\"><code>#485</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/481961c571059137a780aa3d5243ab4d232a016d\"><code>481961c571</code></a>] - Docs: Make rule code examples more consistent.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/e2af8a87cf2a3a1fb892006853b98a423fd7dff6\"><code>e2af8a87cf</code></a>] - Fix: Infinite hop calculation when there’s a cycle (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/486\"><code>#486</code></a>).</li>\n</ul>\n"
-      details:
-        32dcb344bd36a2e5aa94ae2e3589e0d9cb5ad72c:
+      details: 
+        32dcb344bd36a2e5aa94ae2e3589e0d9cb5ad72c: 
           associateCommitId: null
           message: "Fix: Make improvements to `chrome` connector (see also: [`#387`](https://github.com/sonarwhal/sonarwhal/issues/387), and [`#471`](https://github.com/sonarwhal/sonarwhal/issues/471))."
-        97bc6ea26b61b32c98499e4754a66ad48ce21511:
+        97bc6ea26b61b32c98499e4754a66ad48ce21511: 
           associateCommitId: "495"
           message: "Fix: Make `fetchContent` return raw data in chrome."
-        a5b9951d2d2a83d047c22f9b08252974666e1355:
+        a5b9951d2d2a83d047c22f9b08252974666e1355: 
           associateCommitId: "485"
           message: "Fix: Spinner getting stuck issue."
-        481961c571059137a780aa3d5243ab4d232a016d:
+        481961c571059137a780aa3d5243ab4d232a016d: 
           associateCommitId: null
           message: "Docs: Make rule code examples more consistent."
-        e2af8a87cf2a3a1fb892006853b98a423fd7dff6:
+        e2af8a87cf2a3a1fb892006853b98a423fd7dff6: 
           associateCommitId: "486"
           message: "Fix: Infinite hop calculation when there's a cycle."
-    New features:
+    New features: 
       raw: "- [[`ab11a172a3`](https://github.com/sonarwhal/sonarwhal/commit/ab11a172a3d6a0f84a316d63654df29ecd343a7c)] - Update: `snyk-snapshot.json`.\n- [[`78b6cb1bb1`](https://github.com/sonarwhal/sonarwhal/commit/78b6cb1bb1d677aadb316f24e05f56342ffacbcc)] - New: Add rule to check manifest's `name` and `short_name` members (see also: [`#136`](https://github.com/sonarwhal/sonarwhal/issues/136)).\n- [[`7c4947eac1`](https://github.com/sonarwhal/sonarwhal/commit/7c4947eac194c1985ca666b3e504274814b0520e)] - New: Add rule to check `apple-touch-icon`s usage (see also: [`#33`](https://github.com/sonarwhal/sonarwhal/issues/33)).\n- [[`d13e26be35`](https://github.com/sonarwhal/sonarwhal/commit/d13e26be354752ea59740cfc7604952c04d21dcd)] - New: Add `summary` fomatter (see also: [`#487`](https://github.com/sonarwhal/sonarwhal/issues/487)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/ab11a172a3d6a0f84a316d63654df29ecd343a7c\"><code>ab11a172a3</code></a>] - Update: <code>snyk-snapshot.json</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/78b6cb1bb1d677aadb316f24e05f56342ffacbcc\"><code>78b6cb1bb1</code></a>] - New: Add rule to check manifest’s <code>name</code> and <code>short_name</code> members (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/136\"><code>#136</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/7c4947eac194c1985ca666b3e504274814b0520e\"><code>7c4947eac1</code></a>] - New: Add rule to check <code>apple-touch-icon</code>s usage (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/33\"><code>#33</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/d13e26be354752ea59740cfc7604952c04d21dcd\"><code>d13e26be35</code></a>] - New: Add <code>summary</code> fomatter (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/487\"><code>#487</code></a>).</li>\n</ul>\n"
-      details:
-        ab11a172a3d6a0f84a316d63654df29ecd343a7c:
+      details: 
+        ab11a172a3d6a0f84a316d63654df29ecd343a7c: 
           associateCommitId: null
           message: "Update: `snyk-snapshot.json`."
-        78b6cb1bb1d677aadb316f24e05f56342ffacbcc:
+        78b6cb1bb1d677aadb316f24e05f56342ffacbcc: 
           associateCommitId: "136"
           message: "New: Add rule to check manifest's `name` and `short_name` members."
-        7c4947eac194c1985ca666b3e504274814b0520e:
+        7c4947eac194c1985ca666b3e504274814b0520e: 
           associateCommitId: "33"
           message: "New: Add rule to check `apple-touch-icon`s usage."
-        d13e26be354752ea59740cfc7604952c04d21dcd:
+        d13e26be354752ea59740cfc7604952c04d21dcd: 
           associateCommitId: "487"
           message: "New: Add `summary` fomatter."
-  0.5.2 (September 2, 2017):
-    Bug fixes / Improvements:
+  0.5.2 (September 2, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`861931f83d`](https://github.com/sonarwhal/sonarwhal/commit/861931f83d257172efb219f04cc45fbbfd414093)] - Fix: Make `html-checker` rule not break if no HTML is passed.\n- [[`d3899126b8`](https://github.com/sonarwhal/sonarwhal/commit/d3899126b87019a516654757b3ac07f3156f3e53)] - Fix: Error in `onLoadingFailed` (see also: [`#469`](https://github.com/sonarwhal/sonarwhal/issues/469)).\n- [[`4eeeda950f`](https://github.com/sonarwhal/sonarwhal/commit/4eeeda950f20ec737f73df96e4770efb1aa585a5)] - Fix: Improve error messages for `highest-available-document-mode` rule (see also: [`#483`](https://github.com/sonarwhal/sonarwhal/issues/483) and [`#477`](https://github.com/sonarwhal/sonarwhal/issues/477)).\n- [[`19f95d12be`](https://github.com/sonarwhal/sonarwhal/commit/19f95d12be6a4f0c911b343efe541f1e1b321788)] - Fix: Error with `jsdom` and attribute names containing `.` (see also: [`#482`](https://github.com/sonarwhal/sonarwhal/issues/482)).\n- [[`b125186fb7`](https://github.com/sonarwhal/sonarwhal/commit/b125186fb759d9d92b952111681f50b28b71f3f1)] - Fix: Remove `null` locations from error messages (see also: [`#478`](https://github.com/sonarwhal/sonarwhal/issues/478)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/861931f83d257172efb219f04cc45fbbfd414093\"><code>861931f83d</code></a>] - Fix: Make <code>html-checker</code> rule not break if no HTML is passed.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/d3899126b87019a516654757b3ac07f3156f3e53\"><code>d3899126b8</code></a>] - Fix: Error in <code>onLoadingFailed</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/469\"><code>#469</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/4eeeda950f20ec737f73df96e4770efb1aa585a5\"><code>4eeeda950f</code></a>] - Fix: Improve error messages for <code>highest-available-document-mode</code> rule (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/483\"><code>#483</code></a> and <a href=\"https://github.com/sonarwhal/sonarwhal/issues/477\"><code>#477</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/19f95d12be6a4f0c911b343efe541f1e1b321788\"><code>19f95d12be</code></a>] - Fix: Error with <code>jsdom</code> and attribute names containing <code>.</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/482\"><code>#482</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/b125186fb759d9d92b952111681f50b28b71f3f1\"><code>b125186fb7</code></a>] - Fix: Remove <code>null</code> locations from error messages (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/478\"><code>#478</code></a>).</li>\n</ul>\n"
-      details:
-        861931f83d257172efb219f04cc45fbbfd414093:
+      details: 
+        861931f83d257172efb219f04cc45fbbfd414093: 
           associateCommitId: null
           message: "Fix: Make `html-checker` rule not break if no HTML is passed."
-        d3899126b87019a516654757b3ac07f3156f3e53:
+        d3899126b87019a516654757b3ac07f3156f3e53: 
           associateCommitId: "469"
           message: "Fix: Error in `onLoadingFailed`."
-        4eeeda950f20ec737f73df96e4770efb1aa585a5:
+        4eeeda950f20ec737f73df96e4770efb1aa585a5: 
           associateCommitId: null
           message: "Fix: Improve error messages for `highest-available-document-mode` rule (see also: [`#483`](https://github.com/sonarwhal/sonarwhal/issues/483) and [`#477`](https://github.com/sonarwhal/sonarwhal/issues/477))."
-        19f95d12be6a4f0c911b343efe541f1e1b321788:
+        19f95d12be6a4f0c911b343efe541f1e1b321788: 
           associateCommitId: "482"
           message: "Fix: Error with `jsdom` and attribute names containing `.`."
-        b125186fb759d9d92b952111681f50b28b71f3f1:
+        b125186fb759d9d92b952111681f50b28b71f3f1: 
           associateCommitId: "478"
           message: "Fix: Remove `null` locations from error messages."
-  0.5.1 (September 1, 2017):
-    Bug fixes / Improvements:
+  0.5.1 (September 1, 2017): 
+    Bug fixes / Improvements: 
       raw: "- [[`f45b745479`](https://github.com/sonarwhal/sonarwhal/commit/f45b745479d5b38670b6e6f3a9293abda60c3fde)] - Fix: Lock `jsdom` to `v11.1.0` in `package.json`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f45b745479d5b38670b6e6f3a9293abda60c3fde\"><code>f45b745479</code></a>] - Fix: Lock <code>jsdom</code> to <code>v11.1.0</code> in <code>package.json</code>.</li>\n</ul>\n"
-      details:
-        f45b745479d5b38670b6e6f3a9293abda60c3fde:
+      details: 
+        f45b745479d5b38670b6e6f3a9293abda60c3fde: 
           associateCommitId: null
           message: "Fix: Lock `jsdom` to `v11.1.0` in `package.json`."
-  0.5.0 (August 31, 2017):
-    Breaking Changes:
+  0.5.0 (August 31, 2017): 
+    Breaking Changes: 
       raw: "- [[`c2d0282591`](https://github.com/sonarwhal/sonarwhal/commit/c2d0282591b79fab4c32ba45e939b4eb96438237)] - Breaking: Rename `cdp` connector to `chrome` (see also: [`#361`](https://github.com/sonarwhal/sonarwhal/issues/361)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/c2d0282591b79fab4c32ba45e939b4eb96438237\"><code>c2d0282591</code></a>] - Breaking: Rename <code>cdp</code> connector to <code>chrome</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/361\"><code>#361</code></a>).</li>\n</ul>\n"
-      details:
-        c2d0282591b79fab4c32ba45e939b4eb96438237:
+      details: 
+        c2d0282591b79fab4c32ba45e939b4eb96438237: 
           associateCommitId: "361"
           message: "Breaking: Rename `cdp` connector to `chrome`."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`0cc1f05e51`](https://github.com/sonarwhal/sonarwhal/commit/0cc1f05e515755e6f25542c6c4d0362b48e3ba4e)] - Docs: Tweak `no-vulnerable-javascript-libraries` rule related documentation (see also: [`#470`](https://github.com/sonarwhal/sonarwhal/issues/470)).\n- [[`984aabcf7c`](https://github.com/sonarwhal/sonarwhal/commit/984aabcf7c8cdc0d5f77922ea002f75164740a44)] - Fix: Filter out duplicate fetch requests (see also: [`#460`](https://github.com/sonarwhal/sonarwhal/issues/460)).\n- [[`df53c0ef36`](https://github.com/sonarwhal/sonarwhal/commit/df53c0ef36bb642344da1f3a7f9ec27c95e8dd78)] - Fix: Update CLI templates (see also: [`#461`](https://github.com/sonarwhal/sonarwhal/issues/461)).\n- [[`bbf1e6eaa4`](https://github.com/sonarwhal/sonarwhal/commit/bbf1e6eaa401a14733a623a9416292966d8e64e0)] - Fix: Make `content-type` correctly detect the `charset`.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/0cc1f05e515755e6f25542c6c4d0362b48e3ba4e\"><code>0cc1f05e51</code></a>] - Docs: Tweak <code>no-vulnerable-javascript-libraries</code> rule related documentation (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/470\"><code>#470</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/984aabcf7c8cdc0d5f77922ea002f75164740a44\"><code>984aabcf7c</code></a>] - Fix: Filter out duplicate fetch requests (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/460\"><code>#460</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/df53c0ef36bb642344da1f3a7f9ec27c95e8dd78\"><code>df53c0ef36</code></a>] - Fix: Update CLI templates (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/461\"><code>#461</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/bbf1e6eaa401a14733a623a9416292966d8e64e0\"><code>bbf1e6eaa4</code></a>] - Fix: Make <code>content-type</code> correctly detect the <code>charset</code>.</li>\n</ul>\n"
-      details:
-        0cc1f05e515755e6f25542c6c4d0362b48e3ba4e:
+      details: 
+        0cc1f05e515755e6f25542c6c4d0362b48e3ba4e: 
           associateCommitId: "470"
           message: "Docs: Tweak `no-vulnerable-javascript-libraries` rule related documentation."
-        984aabcf7c8cdc0d5f77922ea002f75164740a44:
+        984aabcf7c8cdc0d5f77922ea002f75164740a44: 
           associateCommitId: "460"
           message: "Fix: Filter out duplicate fetch requests."
-        df53c0ef36bb642344da1f3a7f9ec27c95e8dd78:
+        df53c0ef36bb642344da1f3a7f9ec27c95e8dd78: 
           associateCommitId: "461"
           message: "Fix: Update CLI templates."
-        bbf1e6eaa401a14733a623a9416292966d8e64e0:
+        bbf1e6eaa401a14733a623a9416292966d8e64e0: 
           associateCommitId: null
           message: "Fix: Make `content-type` correctly detect the `charset`."
-    New features:
+    New features: 
       raw: "- [[`60c6c725d1`](https://github.com/sonarwhal/sonarwhal/commit/60c6c725d138212b07cee00cc8b508f6b37a2e2d)] - Update: `snyk-snapshot.json`.\n- [[`633f6d3a53`](https://github.com/sonarwhal/sonarwhal/commit/633f6d3a53cca623fff796d0b5e8ce721bf7213c)] - New: Ask about `browserslist` when generating the configs (see also: [`#446`](https://github.com/sonarwhal/sonarwhal/issues/446)).\n- [[`0852ab95b2`](https://github.com/sonarwhal/sonarwhal/commit/0852ab95b27cd9934df6805fe333aedbd102cff8)] - New: Add rule to check for vulnerable libraries (see also: [`#125`](https://github.com/sonarwhal/sonarwhal/issues/125)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/60c6c725d138212b07cee00cc8b508f6b37a2e2d\"><code>60c6c725d1</code></a>] - Update: <code>snyk-snapshot.json</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/633f6d3a53cca623fff796d0b5e8ce721bf7213c\"><code>633f6d3a53</code></a>] - New: Ask about <code>browserslist</code> when generating the configs (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/446\"><code>#446</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/0852ab95b27cd9934df6805fe333aedbd102cff8\"><code>0852ab95b2</code></a>] - New: Add rule to check for vulnerable libraries (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/125\"><code>#125</code></a>).</li>\n</ul>\n"
-      details:
-        60c6c725d138212b07cee00cc8b508f6b37a2e2d:
+      details: 
+        60c6c725d138212b07cee00cc8b508f6b37a2e2d: 
           associateCommitId: null
           message: "Update: `snyk-snapshot.json`."
-        633f6d3a53cca623fff796d0b5e8ce721bf7213c:
+        633f6d3a53cca623fff796d0b5e8ce721bf7213c: 
           associateCommitId: "446"
           message: "New: Ask about `browserslist` when generating the configs."
-        0852ab95b27cd9934df6805fe333aedbd102cff8:
+        0852ab95b27cd9934df6805fe333aedbd102cff8: 
           associateCommitId: "125"
           message: "New: Add rule to check for vulnerable libraries."
-  0.4.0 (August 25, 2017):
-    Breaking Changes:
+  0.4.0 (August 25, 2017): 
+    Breaking Changes: 
       raw: "- [[`e35b778004`](https://github.com/sonarwhal/sonarwhal/commit/e35b778004be3038d0b994f9a258dd454b994622)] - Breaking: Make `content-type` rule use proper fonts types (see also: [`#425`](https://github.com/sonarwhal/sonarwhal/issues/425)).\n- [[`941d439aff`](https://github.com/sonarwhal/sonarwhal/commit/941d439affca16e3af1b0df90e739ee746df2313)] - Breaking: Upgrade `file-type` to `v6.1.0` (see also: [`#428`](https://github.com/sonarwhal/sonarwhal/issues/428)).\n- [[`c03079912b`](https://github.com/sonarwhal/sonarwhal/commit/c03079912beda28a7d4f7b4bc9427b3cd0e8e621)] - Breaking: Use `browserslist` defaults (see also: [`#452`](https://github.com/sonarwhal/sonarwhal/issues/452) and [`#453`](https://github.com/sonarwhal/sonarwhal/issues/453)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/e35b778004be3038d0b994f9a258dd454b994622\"><code>e35b778004</code></a>] - Breaking: Make <code>content-type</code> rule use proper fonts types (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/425\"><code>#425</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/941d439affca16e3af1b0df90e739ee746df2313\"><code>941d439aff</code></a>] - Breaking: Upgrade <code>file-type</code> to <code>v6.1.0</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/428\"><code>#428</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/c03079912beda28a7d4f7b4bc9427b3cd0e8e621\"><code>c03079912b</code></a>] - Breaking: Use <code>browserslist</code> defaults (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/452\"><code>#452</code></a> and <a href=\"https://github.com/sonarwhal/sonarwhal/issues/453\"><code>#453</code></a>).</li>\n</ul>\n"
-      details:
-        e35b778004be3038d0b994f9a258dd454b994622:
+      details: 
+        e35b778004be3038d0b994f9a258dd454b994622: 
           associateCommitId: "425"
           message: "Breaking: Make `content-type` rule use proper fonts types."
-        941d439affca16e3af1b0df90e739ee746df2313:
+        941d439affca16e3af1b0df90e739ee746df2313: 
           associateCommitId: "428"
           message: "Breaking: Upgrade `file-type` to `v6.1.0`."
-        c03079912beda28a7d4f7b4bc9427b3cd0e8e621:
+        c03079912beda28a7d4f7b4bc9427b3cd0e8e621: 
           associateCommitId: null
           message: "Breaking: Use `browserslist` defaults (see also: [`#452`](https://github.com/sonarwhal/sonarwhal/issues/452) and [`#453`](https://github.com/sonarwhal/sonarwhal/issues/453))."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`0507ff7279`](https://github.com/sonarwhal/sonarwhal/commit/0507ff72793989790694695ef2633d8d177218de)] - Docs: Fix link to `no-disallowed-headers` (see also: [`#403`](https://github.com/sonarwhal/sonarwhal/issues/403)).\n- [[`56fc97aa3c`](https://github.com/sonarwhal/sonarwhal/commit/56fc97aa3c4f84f89eb5fb07a59b4c36d8e4deb8)] - Fix: Make `rule-generator` not encode quotes (see also: [`#392`](https://github.com/sonarwhal/sonarwhal/issues/392)).\n- [[`49833d62ca`](https://github.com/sonarwhal/sonarwhal/commit/49833d62ca4e5ccd2c9ad90ad010aabf9587a1f4)] - Fix: `SyntaxError` when using `jsdom` (see also: [`#404`](https://github.com/sonarwhal/sonarwhal/issues/404)).\n- [[`45955ebc5c`](https://github.com/sonarwhal/sonarwhal/commit/45955ebc5ce0473a421cb2bb4445721c2801c50c)] - Docs: Fix link in `strict-transport-security.md` (see also: [`#417`](https://github.com/sonarwhal/sonarwhal/issues/417)).\n- [[`dd161ed3d0`](https://github.com/sonarwhal/sonarwhal/commit/dd161ed3d0abddb10c6bfc9d5be51ca68c916964)] - Docs: Make minor improvements (see also: [`#437`](https://github.com/sonarwhal/sonarwhal/issues/437)).\n- [[`5cc4484a83`](https://github.com/sonarwhal/sonarwhal/commit/5cc4484a836881a6fa0ec40eee56027c143bf2f4)] - Docs: Update `Code of Conduct` links.\n- [[`aa14e6cb57`](https://github.com/sonarwhal/sonarwhal/commit/aa14e6cb573afe07345fa64f489bc17b53c5792d)] - Fix: Avoid analyzing `/favicon.ico` multiple times (see also: [`#427`](https://github.com/sonarwhal/sonarwhal/issues/427)).\n- [[`9755cadf04`](https://github.com/sonarwhal/sonarwhal/commit/9755cadf0442203ca30d2850d4e950ac068b9503)] - Fix: Error when scanning non-existent URL (see also: [`#389`](https://github.com/sonarwhal/sonarwhal/issues/389)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/0507ff72793989790694695ef2633d8d177218de\"><code>0507ff7279</code></a>] - Docs: Fix link to <code>no-disallowed-headers</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/403\"><code>#403</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/56fc97aa3c4f84f89eb5fb07a59b4c36d8e4deb8\"><code>56fc97aa3c</code></a>] - Fix: Make <code>rule-generator</code> not encode quotes (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/392\"><code>#392</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/49833d62ca4e5ccd2c9ad90ad010aabf9587a1f4\"><code>49833d62ca</code></a>] - Fix: <code>SyntaxError</code> when using <code>jsdom</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/404\"><code>#404</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/45955ebc5ce0473a421cb2bb4445721c2801c50c\"><code>45955ebc5c</code></a>] - Docs: Fix link in <code>strict-transport-security.md</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/417\"><code>#417</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/dd161ed3d0abddb10c6bfc9d5be51ca68c916964\"><code>dd161ed3d0</code></a>] - Docs: Make minor improvements (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/437\"><code>#437</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/5cc4484a836881a6fa0ec40eee56027c143bf2f4\"><code>5cc4484a83</code></a>] - Docs: Update <code>Code of Conduct</code> links.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/aa14e6cb573afe07345fa64f489bc17b53c5792d\"><code>aa14e6cb57</code></a>] - Fix: Avoid analyzing <code>/favicon.ico</code> multiple times (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/427\"><code>#427</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/9755cadf0442203ca30d2850d4e950ac068b9503\"><code>9755cadf04</code></a>] - Fix: Error when scanning non-existent URL (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/389\"><code>#389</code></a>).</li>\n</ul>\n"
-      details:
-        0507ff72793989790694695ef2633d8d177218de:
+      details: 
+        0507ff72793989790694695ef2633d8d177218de: 
           associateCommitId: "403"
           message: "Docs: Fix link to `no-disallowed-headers`."
-        56fc97aa3c4f84f89eb5fb07a59b4c36d8e4deb8:
+        56fc97aa3c4f84f89eb5fb07a59b4c36d8e4deb8: 
           associateCommitId: "392"
           message: "Fix: Make `rule-generator` not encode quotes."
-        49833d62ca4e5ccd2c9ad90ad010aabf9587a1f4:
+        49833d62ca4e5ccd2c9ad90ad010aabf9587a1f4: 
           associateCommitId: "404"
           message: "Fix: `SyntaxError` when using `jsdom`."
-        45955ebc5ce0473a421cb2bb4445721c2801c50c:
+        45955ebc5ce0473a421cb2bb4445721c2801c50c: 
           associateCommitId: "417"
           message: "Docs: Fix link in `strict-transport-security.md`."
-        dd161ed3d0abddb10c6bfc9d5be51ca68c916964:
+        dd161ed3d0abddb10c6bfc9d5be51ca68c916964: 
           associateCommitId: "437"
           message: "Docs: Make minor improvements."
-        5cc4484a836881a6fa0ec40eee56027c143bf2f4:
+        5cc4484a836881a6fa0ec40eee56027c143bf2f4: 
           associateCommitId: null
           message: "Docs: Update `Code of Conduct` links."
-        aa14e6cb573afe07345fa64f489bc17b53c5792d:
+        aa14e6cb573afe07345fa64f489bc17b53c5792d: 
           associateCommitId: "427"
           message: "Fix: Avoid analyzing `/favicon.ico` multiple times."
-        9755cadf0442203ca30d2850d4e950ac068b9503:
+        9755cadf0442203ca30d2850d4e950ac068b9503: 
           associateCommitId: "389"
           message: "Fix: Error when scanning non-existent URL."
-    New features:
+    New features: 
       raw: "- [[`2be5a4ba20`](https://github.com/sonarwhal/sonarwhal/commit/2be5a4ba203aea66b6b61ac7e9c2a4c7fdf191f8)] - New: Add rule to check the usage of the `Strict-Transport-Security` header (see also: [`#23`](https://github.com/sonarwhal/sonarwhal/issues/23)).\n- [[`e9e4a95fd7`](https://github.com/sonarwhal/sonarwhal/commit/e9e4a95fd73210d44cb62fa0769082756d136ad0)] - New: Notify users when a new version of `sonar` is available (see also: [`#419`](https://github.com/sonarwhal/sonarwhal/issues/419)).\n- [[`d515c5aa8b`](https://github.com/sonarwhal/sonarwhal/commit/d515c5aa8bf1cba850d4f7bafaeb33588ab3a5f7)] - New: Create a new config file if one doesn't exist (see also: [`#354`](https://github.com/sonarwhal/sonarwhal/issues/354)).\n- [[`12a415f40d`](https://github.com/sonarwhal/sonarwhal/commit/12a415f40dcdb711861b2494be31f0504cac3471)] - New: Add rule to check the usage of the `Set-Cookie` header (see also: [`#24`](https://github.com/sonarwhal/sonarwhal/issues/24)).\n- [[`f70a4d37e8`](https://github.com/sonarwhal/sonarwhal/commit/f70a4d37e8ef24c6165b548c3d45cbfea1e9439b)] - New: Add rule to check the usage of the `viewport` meta tag (see also: [`#82`](https://github.com/sonarwhal/sonarwhal/issues/82)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/2be5a4ba203aea66b6b61ac7e9c2a4c7fdf191f8\"><code>2be5a4ba20</code></a>] - New: Add rule to check the usage of the <code>Strict-Transport-Security</code> header (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/23\"><code>#23</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/e9e4a95fd73210d44cb62fa0769082756d136ad0\"><code>e9e4a95fd7</code></a>] - New: Notify users when a new version of <code>sonar</code> is available (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/419\"><code>#419</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/d515c5aa8bf1cba850d4f7bafaeb33588ab3a5f7\"><code>d515c5aa8b</code></a>] - New: Create a new config file if one doesn’t exist (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/354\"><code>#354</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/12a415f40dcdb711861b2494be31f0504cac3471\"><code>12a415f40d</code></a>] - New: Add rule to check the usage of the <code>Set-Cookie</code> header (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/24\"><code>#24</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/f70a4d37e8ef24c6165b548c3d45cbfea1e9439b\"><code>f70a4d37e8</code></a>] - New: Add rule to check the usage of the <code>viewport</code> meta tag (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/82\"><code>#82</code></a>).</li>\n</ul>\n"
-      details:
-        2be5a4ba203aea66b6b61ac7e9c2a4c7fdf191f8:
+      details: 
+        2be5a4ba203aea66b6b61ac7e9c2a4c7fdf191f8: 
           associateCommitId: "23"
           message: "New: Add rule to check the usage of the `Strict-Transport-Security` header."
-        e9e4a95fd73210d44cb62fa0769082756d136ad0:
+        e9e4a95fd73210d44cb62fa0769082756d136ad0: 
           associateCommitId: "419"
           message: "New: Notify users when a new version of `sonar` is available."
-        d515c5aa8bf1cba850d4f7bafaeb33588ab3a5f7:
+        d515c5aa8bf1cba850d4f7bafaeb33588ab3a5f7: 
           associateCommitId: "354"
           message: "New: Create a new config file if one doesn't exist."
-        12a415f40dcdb711861b2494be31f0504cac3471:
+        12a415f40dcdb711861b2494be31f0504cac3471: 
           associateCommitId: "24"
           message: "New: Add rule to check the usage of the `Set-Cookie` header."
-        f70a4d37e8ef24c6165b548c3d45cbfea1e9439b:
+        f70a4d37e8ef24c6165b548c3d45cbfea1e9439b: 
           associateCommitId: "82"
           message: "New: Add rule to check the usage of the `viewport` meta tag."
-  0.3.0 (July 1, 2017):
-    Breaking Changes:
+  0.3.0 (July 1, 2017): 
+    Breaking Changes: 
       raw: "- [[`acfd196ed7`](https://github.com/sonarwhal/sonarwhal/commit/acfd196ed708b4f40d08ea9c7063a6d60dd2f812)] - Breaking: Rename `disallowed-headers` rule.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/acfd196ed708b4f40d08ea9c7063a6d60dd2f812\"><code>acfd196ed7</code></a>] - Breaking: Rename <code>disallowed-headers</code> rule.</li>\n</ul>\n"
-      details:
-        acfd196ed708b4f40d08ea9c7063a6d60dd2f812:
+      details: 
+        acfd196ed708b4f40d08ea9c7063a6d60dd2f812: 
           associateCommitId: null
           message: "Breaking: Rename `disallowed-headers` rule."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`d55171d36e`](https://github.com/sonarwhal/sonarwhal/commit/d55171d36e367c46b3d0ec2f791c7ec2d955bd52)] - Docs: Add missing `)` in x-content-type-options.md.\n- [[`28c782db16`](https://github.com/sonarwhal/sonarwhal/commit/28c782db16ca6140a083fae76f143a05f595694e)] - Fix: Make `disown-opener` ignore certain protocols.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/d55171d36e367c46b3d0ec2f791c7ec2d955bd52\"><code>d55171d36e</code></a>] - Docs: Add missing <code>)</code> in x-content-type-options.md.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/28c782db16ca6140a083fae76f143a05f595694e\"><code>28c782db16</code></a>] - Fix: Make <code>disown-opener</code> ignore certain protocols.</li>\n</ul>\n"
-      details:
-        d55171d36e367c46b3d0ec2f791c7ec2d955bd52:
+      details: 
+        d55171d36e367c46b3d0ec2f791c7ec2d955bd52: 
           associateCommitId: null
           message: "Docs: Add missing `)` in x-content-type-options.md."
-        28c782db16ca6140a083fae76f143a05f595694e:
+        28c782db16ca6140a083fae76f143a05f595694e: 
           associateCommitId: null
           message: "Fix: Make `disown-opener` ignore certain protocols."
-  0.2.0 (July 2, 2017):
-    Breaking Changes:
+  0.2.0 (July 2, 2017): 
+    Breaking Changes: 
       raw: "- [[`8b202fb8d9`](https://github.com/sonarwhal/sonarwhal/commit/8b202fb8d930248275fe9984ba23e868be35f77c)] - Breaking: Disable `ssllabs` rule by default (see also: [`#355`](https://github.com/sonarwhal/sonarwhal/issues/355)).\n- [[`6fcb46ae17`](https://github.com/sonarwhal/sonarwhal/commit/6fcb46ae17abc1933f8ee30b98cad59d15be9843)] - Breaking: Use `connector` instead of `collector` (see also: [`#286`](https://github.com/sonarwhal/sonarwhal/issues/286), and [`#358`](https://github.com/sonarwhal/sonarwhal/issues/358)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/8b202fb8d930248275fe9984ba23e868be35f77c\"><code>8b202fb8d9</code></a>] - Breaking: Disable <code>ssllabs</code> rule by default (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/355\"><code>#355</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/6fcb46ae17abc1933f8ee30b98cad59d15be9843\"><code>6fcb46ae17</code></a>] - Breaking: Use <code>connector</code> instead of <code>collector</code> (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/286\"><code>#286</code></a>, and <a href=\"https://github.com/sonarwhal/sonarwhal/issues/358\"><code>#358</code></a>).</li>\n</ul>\n"
-      details:
-        8b202fb8d930248275fe9984ba23e868be35f77c:
+      details: 
+        8b202fb8d930248275fe9984ba23e868be35f77c: 
           associateCommitId: "355"
           message: "Breaking: Disable `ssllabs` rule by default."
-        6fcb46ae17abc1933f8ee30b98cad59d15be9843:
+        6fcb46ae17abc1933f8ee30b98cad59d15be9843: 
           associateCommitId: null
           message: "Breaking: Use `connector` instead of `collector` (see also: [`#286`](https://github.com/sonarwhal/sonarwhal/issues/286), and [`#358`](https://github.com/sonarwhal/sonarwhal/issues/358))."
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`b9d278e7a1`](https://github.com/sonarwhal/sonarwhal/commit/b9d278e7a189f4bb12992f0bdcbf78cd471f95c1)] - Docs: Move `CODE_OF_CONDUCT.md` in the root (see also: [`#353`](https://github.com/sonarwhal/sonarwhal/issues/353)).\n- [[`7b904d6b4f`](https://github.com/sonarwhal/sonarwhal/commit/7b904d6b4f68bcf8b757a1aa3b04b842e5f0317b)] - Docs: Fix broken links (see also: [`#363`](https://github.com/sonarwhal/sonarwhal/issues/363)).\n- [[`ae149ba609`](https://github.com/sonarwhal/sonarwhal/commit/ae149ba60916e593b2afc0d64252e43d527e6e64)] - Docs: Add pull request related guidelines (see also: [`#373`](https://github.com/sonarwhal/sonarwhal/issues/373)).\n- [[`d52247d3e1`](https://github.com/sonarwhal/sonarwhal/commit/d52247d3e10686255c8596aaf494b0bb26cd954e)] - Docs: Add note about handling permission issues (see also: [`#308`](https://github.com/sonarwhal/sonarwhal/issues/308), and [`#364`](https://github.com/sonarwhal/sonarwhal/issues/364)).\n- [[`9cd8d7fdc9`](https://github.com/sonarwhal/sonarwhal/commit/9cd8d7fdc9baf68c59a823801de04c87f49b31d8)] - Docs: Fix broken links in `pull-requests.md`.\n- [[`fd6c083f84`](https://github.com/sonarwhal/sonarwhal/commit/fd6c083f841132189a54e3d8d3bba9ff88473e1d)] - Docs: Make minor improvements (see also: [`#367`](https://github.com/sonarwhal/sonarwhal/issues/367)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/b9d278e7a189f4bb12992f0bdcbf78cd471f95c1\"><code>b9d278e7a1</code></a>] - Docs: Move <code>CODE_OF_CONDUCT.md</code> in the root (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/353\"><code>#353</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/7b904d6b4f68bcf8b757a1aa3b04b842e5f0317b\"><code>7b904d6b4f</code></a>] - Docs: Fix broken links (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/363\"><code>#363</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/ae149ba60916e593b2afc0d64252e43d527e6e64\"><code>ae149ba609</code></a>] - Docs: Add pull request related guidelines (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/373\"><code>#373</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/d52247d3e10686255c8596aaf494b0bb26cd954e\"><code>d52247d3e1</code></a>] - Docs: Add note about handling permission issues (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/308\"><code>#308</code></a>, and <a href=\"https://github.com/sonarwhal/sonarwhal/issues/364\"><code>#364</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/9cd8d7fdc9baf68c59a823801de04c87f49b31d8\"><code>9cd8d7fdc9</code></a>] - Docs: Fix broken links in <code>pull-requests.md</code>.</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/fd6c083f841132189a54e3d8d3bba9ff88473e1d\"><code>fd6c083f84</code></a>] - Docs: Make minor improvements (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/367\"><code>#367</code></a>).</li>\n</ul>\n"
-      details:
-        b9d278e7a189f4bb12992f0bdcbf78cd471f95c1:
+      details: 
+        b9d278e7a189f4bb12992f0bdcbf78cd471f95c1: 
           associateCommitId: "353"
           message: "Docs: Move `CODE_OF_CONDUCT.md` in the root."
-        7b904d6b4f68bcf8b757a1aa3b04b842e5f0317b:
+        7b904d6b4f68bcf8b757a1aa3b04b842e5f0317b: 
           associateCommitId: "363"
           message: "Docs: Fix broken links."
-        ae149ba60916e593b2afc0d64252e43d527e6e64:
+        ae149ba60916e593b2afc0d64252e43d527e6e64: 
           associateCommitId: "373"
           message: "Docs: Add pull request related guidelines."
-        d52247d3e10686255c8596aaf494b0bb26cd954e:
+        d52247d3e10686255c8596aaf494b0bb26cd954e: 
           associateCommitId: null
           message: "Docs: Add note about handling permission issues (see also: [`#308`](https://github.com/sonarwhal/sonarwhal/issues/308), and [`#364`](https://github.com/sonarwhal/sonarwhal/issues/364))."
-        9cd8d7fdc9baf68c59a823801de04c87f49b31d8:
+        9cd8d7fdc9baf68c59a823801de04c87f49b31d8: 
           associateCommitId: null
           message: "Docs: Fix broken links in `pull-requests.md`."
-        fd6c083f841132189a54e3d8d3bba9ff88473e1d:
+        fd6c083f841132189a54e3d8d3bba9ff88473e1d: 
           associateCommitId: "367"
           message: "Docs: Make minor improvements."
-    New features:
+    New features: 
       raw: "- [[`08f36db2b4`](https://github.com/sonarwhal/sonarwhal/commit/08f36db2b4b9736f5c7f0522861cda8eed658926)] - New: Add rule to check markup validity (see also: [`#28`](https://github.com/sonarwhal/sonarwhal/issues/28)).\n- [[`2893a0a7c1`](https://github.com/sonarwhal/sonarwhal/commit/2893a0a7c16abca27c1ce457d0ff05d7334b093f)] - New: Make connectors download manifest & favicon (see also: [`#71`](https://github.com/sonarwhal/sonarwhal/issues/71)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/08f36db2b4b9736f5c7f0522861cda8eed658926\"><code>08f36db2b4</code></a>] - New: Add rule to check markup validity (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/28\"><code>#28</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/2893a0a7c16abca27c1ce457d0ff05d7334b093f\"><code>2893a0a7c1</code></a>] - New: Make connectors download manifest &amp; favicon (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/71\"><code>#71</code></a>).</li>\n</ul>\n"
-      details:
-        08f36db2b4b9736f5c7f0522861cda8eed658926:
+      details: 
+        08f36db2b4b9736f5c7f0522861cda8eed658926: 
           associateCommitId: "28"
           message: "New: Add rule to check markup validity."
-        2893a0a7c16abca27c1ce457d0ff05d7334b093f:
+        2893a0a7c16abca27c1ce457d0ff05d7334b093f: 
           associateCommitId: "71"
           message: "New: Make connectors download manifest & favicon."
-  0.1.0 (June 30, 2017):
-    Breaking changes:
+  0.1.0 (June 30, 2017): 
+    Breaking changes: 
       raw: "- [[`2e29881377d`](https://github.com/sonarwhal/sonarwhal/commit/2e29881377dd36a2e8d13b006482346b18b6bc73)] -\n- Change how `sonar` resources are loaded\n- (see also: [`#234`](https://github.com/sonarwhal/sonarwhal/issues/234)).\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/2e29881377dd36a2e8d13b006482346b18b6bc73\"><code>2e29881377d</code></a>]  Change how <code>sonar</code> resources are loaded (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/234\"><code>#234</code></a>).</li>\n</ul>\n"
       details: {}
-    Bug fixes / Improvements:
+    Bug fixes / Improvements: 
       raw: "- [[`98e3b2e5aa3`](https://github.com/sonarwhal/sonarwhal/commit/98e3b2e5aa34445e7871f897071f7216f7fdd561)] -\n- Fix `Could not find node with given id` error\n- (see also: [`#275`](https://github.com/sonarwhal/sonarwhal/issues/275)).\n- [[`48ed6e9e19c`](https://github.com/sonarwhal/sonarwhal/commit/48ed6e9e19ccf47e84f6e960cc37be1dd2b2a262)] -\n- Refactor `CDP` related code\n- (see also:\n- [`#311`](https://github.com/sonarwhal/sonarwhal/issues/311),\n- [`#330`](https://github.com/sonarwhal/sonarwhal/issues/330),\n- [`#324`](https://github.com/sonarwhal/sonarwhal/issues/324), and\n- [`#332`](https://github.com/sonarwhal/sonarwhal/issues/332)).\n- [[`c3803821c06`](https://github.com/sonarwhal/sonarwhal/commit/c3803821c0619b5210f5fe0fd1a37d27fb9a1143)] -\n- Improve requester\n- (see also: [`#260`](https://github.com/sonarwhal/sonarwhal/issues/260)).\n- [[`b613918fdde`](https://github.com/sonarwhal/sonarwhal/commit/b613918fdde302106a3b777f70df0c9a31fcc37c)] -\n- Improve documentation.\n\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/98e3b2e5aa34445e7871f897071f7216f7fdd561\"><code>98e3b2e5aa3</code></a>]  Fix <code>Could not find node with given id</code> error (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/275\"><code>#275</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/48ed6e9e19ccf47e84f6e960cc37be1dd2b2a262\"><code>48ed6e9e19c</code></a>]  Refactor <code>CDP</code> related code (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/311\"><code>#311</code></a>, <a href=\"https://github.com/sonarwhal/sonarwhal/issues/330\"><code>#330</code></a>, <a href=\"https://github.com/sonarwhal/sonarwhal/issues/324\"><code>#324</code></a>, and <a href=\"https://github.com/sonarwhal/sonarwhal/issues/332\"><code>#332</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/c3803821c0619b5210f5fe0fd1a37d27fb9a1143\"><code>c3803821c06</code></a>]  Improve requester (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/260\"><code>#260</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/b613918fdde302106a3b777f70df0c9a31fcc37c\"><code>b613918fdde</code></a>]  Improve documentation.</li>\n</ul>\n"
       details: {}
-    New features:
-      raw: "- [[`3e2863b3963`](https://github.com/sonarwhal/sonarwhal/commit/3e2863b3963403406b178b46ade8b62824e432bd)] -\n- Add support for rule shorthands, and ability to specify rules as an array\n- (see also: [`#283`](https://github.com/sonarwhal/sonarwhal/issues/283)).\n- [[`b54dd55b48a`](https://github.com/sonarwhal/sonarwhal/commit/b54dd55b48aada5e2fd63df002a2d2096e1164be)] -\n- Add rule generator\n- (see also: [`#238`](https://github.com/sonarwhal/sonarwhal/issues/238)).\n- [[`70018b6b33b`](https://github.com/sonarwhal/sonarwhal/commit/70018b6b33bca821cab9de23900d47dac24b1524)] -\n- Make `disown-opener` rule use `targetedBrowsers`.\n\n\n"
+    New features: 
+      raw: "- [[`3e2863b3963`](https://github.com/sonarwhal/sonarwhal/commit/3e2863b3963403406b178b46ade8b62824e432bd)] -\n- Add support for rule shorthands, and ability to specify rules as an array\n- (see also: [`#283`](https://github.com/sonarwhal/sonarwhal/issues/283)).\n- [[`b54dd55b48a`](https://github.com/sonarwhal/sonarwhal/commit/b54dd55b48aada5e2fd63df002a2d2096e1164be)] -\n- Add rule generator\n- (see also: [`#238`](https://github.com/sonarwhal/sonarwhal/issues/238)).\n- [[`70018b6b33b`](https://github.com/sonarwhal/sonarwhal/commit/70018b6b33bca821cab9de23900d47dac24b1524)] -\n- Make `disown-opener` rule use `targetedBrowsers`.\n"
       html: "<ul>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/3e2863b3963403406b178b46ade8b62824e432bd\"><code>3e2863b3963</code></a>]  Add support for rule shorthands, and ability to specify rules as an array (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/283\"><code>#283</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/b54dd55b48aada5e2fd63df002a2d2096e1164be\"><code>b54dd55b48a</code></a>]  Add rule generator (see also: <a href=\"https://github.com/sonarwhal/sonarwhal/issues/238\"><code>#238</code></a>).</li>\n<li>[<a href=\"https://github.com/sonarwhal/sonarwhal/commit/70018b6b33bca821cab9de23900d47dac24b1524\"><code>70018b6b33b</code></a>]  Make <code>disown-opener</code> rule use <code>targetedBrowsers</code>.</li>\n</ul>\n"
       details: {}

--- a/src/hexo/themes/sonarwhal/layout/partials/sub-page.hbs
+++ b/src/hexo/themes/sonarwhal/layout/partials/sub-page.hbs
@@ -33,38 +33,27 @@
             <div class="module module--secondary mobile-view">
                 <ul class="toc-mobile-view">
                     <li>
-                        <p role="button" id="mobile-toc" aria-controls="mobile-toc-submenu" aria-expanded="false" aria-haspopup="true" class="toc-mobile-view__button expandable">User Guide</p>
+                        <p role="button" id="mobile-toc" aria-controls="mobile-toc-submenu" aria-expanded="false" aria-haspopup="true" class="toc-mobile-view__button expandable">{{capitalize page.category}}</p>
                         <ul role="group" class="toc-mobile-view__dropdown" id="mobile-toc-submenu" aria-hidden="true">
+                             {{#if (isNotGuideIndexPage page)}}
                             <li class="dropdown__subitem">
+                                <a href="../{{#if (isNotSectionIndexPage page)}}../{{/if}}" class="subitem--single">Getting Started</a>
+                            </li>
+                            {{else}}
+                             <li class="dropdown__subitem">
                                 <a href="#" class="subitem--single">Getting Started</a>
                             </li>
+                            {{/if}}
+                            {{#each (getSortedToCTitles pages)}}
                             <li class="dropdown__subitem">
-                                <p>Concepts</p>
+                                <p>{{this}}</p>
                                 <ul>
-                                    <li class="subitem"><a href="#">Connectors</a></li>
-                                    <li class="subitem"><a href="#">Formatters</a></li>
-                                    <li class="subitem"><a href="#">Rules</a></li>
+                                    {{#each (getPagesByToCTitle this ../pages)}}
+                                    <li class="subitem"><a href="{{sanitize permalink}}">{{title}}</a></li>
+                                    {{/each}}
                                 </ul>
                             </li>
-                            <li class="dropdown__subitem">
-                                <p>Further Configuration</p>
-                                <ul>
-                                    <li class="subitem"><a href="#">.sonarwhalrc formats</a></li>
-                                    <li class="subitem"><a href="#">Browser configuration</a></li>
-                                    <li class="subitem"><a href="#">Ignoring domains</a></li>
-                                    <li class="subitem"><a href="#">Rules timeout</a></li>
-                                </ul>
-                            </li>
-                            <li class="dropdown__subitem">
-                                <p>Rules</p>
-                                <ul>
-                                    <li class="subitem"><a href="#">Rule categories</a></li>
-                                    <li class="subitem"><a href="#">AMP HTML Validator</a></li>
-                                    <li class="subitem"><a href="#">Accessibility assessment with aXe</a></li>
-                                    <li class="subitem"><a href="#">Avoid HTTP redirects in requests</a></li>
-                                    <li class="subitem"><a href="#">Disallow certain HTTP headers</a></li>
-                                </ul>
-                            </li>
+                            {{/each}}
                         </ul>
                     </li>
                 </ul>

--- a/src/hexo/themes/sonarwhal/layout/partials/sub-page.hbs
+++ b/src/hexo/themes/sonarwhal/layout/partials/sub-page.hbs
@@ -30,10 +30,46 @@
     </header>
     <div class="section">
         <div class="layout layout--sidebar">
-            <div class="module module--primary wrap-text">
-                {{{page.content}}}
+            <div class="module module--secondary mobile-view">
+                <ul class="toc-mobile-view">
+                    <li>
+                        <p role="button" id="mobile-toc" aria-controls="mobile-toc-submenu" aria-expanded="false" aria-haspopup="true" class="toc-mobile-view__button expandable">User Guide</p>
+                        <ul role="group" class="toc-mobile-view__dropdown" id="mobile-toc-submenu" aria-hidden="true">
+                            <li class="dropdown__subitem">
+                                <a href="#" class="subitem--single">Getting Started</a>
+                            </li>
+                            <li class="dropdown__subitem">
+                                <p>Concepts</p>
+                                <ul>
+                                    <li class="subitem"><a href="#">Connectors</a></li>
+                                    <li class="subitem"><a href="#">Formatters</a></li>
+                                    <li class="subitem"><a href="#">Rules</a></li>
+                                </ul>
+                            </li>
+                            <li class="dropdown__subitem">
+                                <p>Further Configuration</p>
+                                <ul>
+                                    <li class="subitem"><a href="#">.sonarwhalrc formats</a></li>
+                                    <li class="subitem"><a href="#">Browser configuration</a></li>
+                                    <li class="subitem"><a href="#">Ignoring domains</a></li>
+                                    <li class="subitem"><a href="#">Rules timeout</a></li>
+                                </ul>
+                            </li>
+                            <li class="dropdown__subitem">
+                                <p>Rules</p>
+                                <ul>
+                                    <li class="subitem"><a href="#">Rule categories</a></li>
+                                    <li class="subitem"><a href="#">AMP HTML Validator</a></li>
+                                    <li class="subitem"><a href="#">Accessibility assessment with aXe</a></li>
+                                    <li class="subitem"><a href="#">Avoid HTTP redirects in requests</a></li>
+                                    <li class="subitem"><a href="#">Disallow certain HTTP headers</a></li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
             </div>
-            <div class="module module--secondary table-of-contents treeview" role="navigation">
+            <div class="module module--secondary table-of-contents treeview main-view" role="navigation">
                 <ul role="tree" aria-labelledby="page-heading" tabindex="0">
                 {{#each (getSortedToCTitles pages)}}
                     <li role="treeitem" aria-label="subsection" tabindex="0"
@@ -76,6 +112,9 @@
                     </li>
                 {{/each}}
                 </ul>
+            </div>
+            <div class="module module--primary wrap-text">
+                {{{page.content}}}
             </div>
         </div>
     </div>

--- a/src/hexo/themes/sonarwhal/source/components/treeview/treeview.js
+++ b/src/hexo/themes/sonarwhal/source/components/treeview/treeview.js
@@ -16,6 +16,7 @@
 
     var treeitems = arraify(document.querySelectorAll('[role="treeitem"]'));
     var tocSectionTitle = arraify(document.querySelectorAll('.toc-section-title, .toc-section-title--active'));
+    var mobileToCMenu = document.querySelector('.toc-mobile-view');
     var findParentElementByAttribute = function (element, attrName, attrValue) {
         var currentElement = element;
 
@@ -166,6 +167,17 @@
         }
     };
 
+    var toggleExpandMobileMenu = function (evt) {
+        var menu = evt.currentTarget.querySelector('#mobile-toc-submenu');
+        var isClosed = menu.getAttribute('aria-hidden') === 'true';
+
+        if (isClosed) {
+            menu.setAttribute('aria-hidden', 'false');
+        } else {
+            menu.setAttribute('aria-hidden', 'true');
+        }
+    };
+
     var onKeydown = function (evt) {
         var key = evt.which || evt.keyCode;
         var currentTreeitem = getClosestTreeElement(evt.target);
@@ -223,4 +235,6 @@
     tocSectionTitle.map(function (title) {
         title.addEventListener('click', toggleExpand, false);
     });
+
+    mobileToCMenu.addEventListener('click', toggleExpandMobileMenu, false);
 }());

--- a/src/hexo/themes/sonarwhal/source/core/css/table-of-contents.css
+++ b/src/hexo/themes/sonarwhal/source/core/css/table-of-contents.css
@@ -60,7 +60,7 @@ li div.toc-subsection-title--active a::before {
 
 /* Mobile View ToC */
 
-@media (max-width:47.9em) {
+@media (max-width: 47.9em) {
 
     .main-view {
         display: none;
@@ -96,7 +96,7 @@ li div.toc-subsection-title--active a::before {
     .toc-mobile-view__button::after {
         position: absolute;
         right: 1rem;
-        content: url(/images/toc-arrow.svg);
+        content: url("/images/toc-arrow.svg");
         width: 1.4rem;
         vertical-align: top;
     }
@@ -126,7 +126,7 @@ li div.toc-subsection-title--active a::before {
 
     .subitem--single:hover,
     .subitem:hover {
-        background-color: hsla(0, 0%, 0%,.1);
+        background-color: hsla(0, 0%, 0%, .1);
     }
 
     .toc-mobile-view__dropdown {
@@ -145,14 +145,14 @@ li div.toc-subsection-title--active a::before {
         border-bottom-right-radius: .3rem;
 
         z-index: 10;
-        overflow-y:scroll;
+        overflow-y: scroll;
         list-style-type: none;
         box-sizing: content-box;
     }
 
 }
 
-@media (min-width:47.9em) {
+@media (min-width: 47.9em) {
 
     .mobile-view {
         display: none;

--- a/src/hexo/themes/sonarwhal/source/core/css/table-of-contents.css
+++ b/src/hexo/themes/sonarwhal/source/core/css/table-of-contents.css
@@ -57,3 +57,105 @@ li div.toc-subsection-title--active a::before {
     left: 0;
     width: 1.5rem;
 }
+
+/* Mobile View ToC */
+
+@media (max-width:47.9em) {
+
+    .main-view {
+        display: none;
+    }
+
+    .mobile-view {
+        position: relative;
+        max-width: 64rem;
+    }
+
+    .toc-mobile-view {
+        position: relative;
+        margin: 0;
+        background-color: #e2e2e2;
+        border: 1px solid #999;
+        border-radius: .3rem;
+        list-style: none;
+    }
+
+    .toc-mobile-view > ul li,
+    .toc-mobile-view > ul li > ul,
+    .dropdown__subitem > ul,
+    .subitem {
+        margin: 0;
+        list-style: none;
+    }
+
+    .toc-mobile-view__button {
+        display: block;
+        padding: .5rem 1.5rem;
+    }
+
+    .toc-mobile-view__button::after {
+        position: absolute;
+        right: 1rem;
+        content: url(/images/toc-arrow.svg);
+        width: 1.4rem;
+        vertical-align: top;
+    }
+
+    .dropdown__subitem {
+        margin-top: .5rem;
+    }
+
+    .subitem--single,
+    .dropdown__subitem p {
+        padding: 0 1.5rem;
+    }
+
+    .dropdown__subitem ul > li {
+        padding: .5rem 3rem;
+    }
+
+    .subitem--single {
+        display: block;
+        padding: .5rem 3rem;
+    }
+
+    .toc-mobile-view__button,
+    .subitem {
+        cursor: pointer;
+    }
+
+    .subitem--single:hover,
+    .subitem:hover {
+        background-color: hsla(0, 0%, 0%,.1);
+    }
+
+    .toc-mobile-view__dropdown {
+        position: absolute;
+        left: -.1rem;
+        top: 3.4rem;
+        max-height: 48rem;
+        width: 100%;
+        max-width: 64rem;
+        margin: 0;
+
+        background-color: #e2e2e2;
+        border: 1px solid #999;
+        border-top: none;
+        border-bottom-left-radius: .3rem;
+        border-bottom-right-radius: .3rem;
+
+        z-index: 10;
+        overflow-y:scroll;
+        list-style-type: none;
+        box-sizing: content-box;
+    }
+
+}
+
+@media (min-width:47.9em) {
+
+    .mobile-view {
+        display: none;
+    }
+
+}


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

Front-end for dropdown table of contents for the documentation pages on mobile/smaller screens.

Fix #198

**I need help getting the dropdown to open**, and placeholders for what links that are currently in place as I assume there's some handlebars code to be written.

Since this is using a different structure from the table of contents on the larger screens, I don't know what can be reused from the handlebars code. 