### PR TITLE
New: Add expand all button to scan results

### DIFF
--- a/src/sonarwhal-theme/layout/partials/scan-result.hbs
+++ b/src/sonarwhal-theme/layout/partials/scan-result.hbs
@@ -108,8 +108,11 @@
                         <div class="module module--primary results">
                             {{#each categories as |category|}}
                             <section class="rule-result" id="{{name}}">
-                                <h3>{{name}}</h3>
-                                {{#unless (isFinish ../status)}}
+                                <div class="rule-result--category">
+                                    <h3>{{name}}</h3>
+                                    <button title="expand" class="button-expand-all">+ Expand All</button>
+                                    {{#unless (isFinish ../status)}}
+                                </div>
                                 <div class="rule-result--details compiling__loader">
                                     <div class="rule-result__message--compiling">
                                         <div class="rule-result__message--compiling__loader"></div>

--- a/src/sonarwhal-theme/layout/partials/scan-result.hbs
+++ b/src/sonarwhal-theme/layout/partials/scan-result.hbs
@@ -110,7 +110,11 @@
                             <section class="rule-result" id="{{name}}">
                                 <div class="rule-result--category">
                                     <h3>{{name}}</h3>
-                                    <button title="expand" class="button-expand-all">+ Expand All</button>
+                                    {{#if (isFinish ../status)}}
+                                        {{#unless (noIssue category)}}
+                                        <button title="expand" class="button-expand-all closed">+ expand all</button>
+                                        {{/unless}}
+                                    {{/if}}
                                 </div>
                                 {{#unless (isFinish ../status)}}
                                 <div class="rule-result--details compiling__loader">

--- a/src/sonarwhal-theme/layout/partials/scan-result.hbs
+++ b/src/sonarwhal-theme/layout/partials/scan-result.hbs
@@ -111,8 +111,8 @@
                                 <div class="rule-result--category">
                                     <h3>{{name}}</h3>
                                     <button title="expand" class="button-expand-all">+ Expand All</button>
-                                    {{#unless (isFinish ../status)}}
                                 </div>
+                                {{#unless (isFinish ../status)}}
                                 <div class="rule-result--details compiling__loader">
                                     <div class="rule-result__message--compiling">
                                         <div class="rule-result__message--compiling__loader"></div>

--- a/src/sonarwhal-theme/source/core/css/scan-results.css
+++ b/src/sonarwhal-theme/source/core/css/scan-results.css
@@ -232,7 +232,7 @@
     margin-bottom: 0;
     padding: .5rem 1rem;
     font-size: 1.2rem;
-    background-color: #ffffff;
+    background-color: #f0f0f0;
     color: #4046dd;
 }
 

--- a/src/sonarwhal-theme/source/core/css/scan-results.css
+++ b/src/sonarwhal-theme/source/core/css/scan-results.css
@@ -220,6 +220,22 @@
     border: 1px solid #e2e2e2;
 }
 
+.rule-result--category {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.button-expand-all {
+    position: relative;
+    min-width: 11.4rem;
+    margin-bottom: 0;
+    padding: .5rem 1rem;
+    font-size: 1.2rem;
+    background-color: #ffffff;
+    color: #4046dd;
+}
+
 .rule-result h3 {
     text-transform: capitalize;
 }

--- a/src/sonarwhal-theme/source/js/scanner-common.js
+++ b/src/sonarwhal-theme/source/js/scanner-common.js
@@ -37,16 +37,34 @@
         item.setAttribute('aria-expanded', 'false');
     };
 
-    var toggleExpand = function (evt) {
-        var element = evt.target;
+    var childRulesExpanded = function (element) {
+        var parent = element.closest('.rule-result');
+        var details = Array.prototype.slice.apply(parent.querySelectorAll('.rule-result--details'));
 
-        if (element.className.indexOf('button--details') === -1) {
-            return;
+        return details.some(function (detail) {
+            return (detail.getAttribute('aria-expanded') === 'true');
+        });
+    };
+
+    var updateExpandAllButton = function (element, closeAll) {
+        var expanded = typeof closecloseAll !== 'undefined' ? closeAll : childRulesExpanded(element);
+
+        if (expanded) {
+            element.innerHTML = '- close all';
+            element.classList.remove('closed');
+            element.classList.add('expanded');
+        } else {
+            element.innerHTML = '+ expand all';
+            element.classList.remove('expanded');
+            element.classList.add('closed');
         }
+    };
 
+    var toggleExpandRule = function (element, closeAll) {
         var parent = element.closest('.rule-result--details');
-        var expanded = parent.getAttribute('aria-expanded') === 'true';
+        var expanded = typeof closeAll !== 'undefined' ? closeAll : parent.getAttribute('aria-expanded') === 'true';
         var name = element.getAttribute('data-rule');
+        var expandAllButton = parent.closest('.rule-result').querySelector('.button-expand-all');
 
         if (expanded) {
             collapseDetails(parent);
@@ -56,6 +74,38 @@
             expandDetails(parent);
             element.innerHTML = 'close details';
             element.setAttribute('title', 'close ' + name + '\'s result details');
+        }
+
+        updateExpandAllButton(expandAllButton);
+        // if all rules are closed, toggle button to '- open all'.
+        // if any rule is open, toggle button to '- close all'.
+    };
+
+    var toggleExpandAll = function (element) {
+        var parent = element.closest('.rule-result');
+        var detailButtons = Array.prototype.slice.apply(parent.querySelectorAll('.button--details'));
+        var expanded = element.classList.contains('expanded');
+
+        for (var i = 0; i < detailButtons.length; i++) {
+            if (expanded) {
+                toggleExpandRule(detailButtons[i], true);
+            } else {
+                toggleExpandRule(detailButtons[i], false);
+            }
+        }
+
+        updateExpandAllButton(element, !expanded);
+    };
+
+    var toggleExpand = function (evt) {
+        var element = evt.target;
+
+        if (element.className.indexOf('button--details') !== -1) {
+            toggleExpandRule(element);
+        }
+
+        if (element.className.indexOf('button-expand-all') !== -1) {
+            toggleExpandAll(element);
         }
     };
 

--- a/src/sonarwhal-theme/source/js/scanner-submit.js
+++ b/src/sonarwhal-theme/source/js/scanner-submit.js
@@ -161,8 +161,15 @@
         }
 
         var container = document.getElementById(category.name);
+        var expandAllButton = container.querySelector('.button-expand-all');
         var loader = container.querySelector('.compiling__loader');
         var ruleResult = getHTML(ruleItemTemplate, category);
+
+        if (!expandAllButton) {
+            var buttonTemplate = '<button title="expand" class="button-expand-all closed">+ expand all</button>';
+
+            container.querySelector('.rule-result--category').insertAdjacentHTML('beforeend', buttonTemplate);
+        }
 
         loader.insertAdjacentHTML('beforebegin', ruleResult);
     };


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

Fix #254

Adds expand all button each category of scan results. 

**Help wanted:** When all the results are expanded the button should say "- Close All"