### PR TITLE
Fix: Allow `-` in title of subsections

### DIFF
--- a/helpers/updater.js
+++ b/helpers/updater.js
@@ -131,7 +131,7 @@ const generateFrontMatterInfo = (filePath, title, description, currentFrontMatte
         layout,
         permalink,
         title,
-        tocTitle
+        tocTitle: tocTitle ? tocTitle.replace(/-/g, ' ') : tocTitle
     };
 
     const finalFrontMatterData = _.assign(newFrontMatter, existingFrontMatter);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

This allows to have `getting-started` as the name of the folder and
display it as `Getting started` on the live site.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: https://github.com/sonarwhal/sonarwhal/pull/784#issue-292052808

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
