### PR TITLE
Fix: Copy markdown images in the gulp task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ src/content/about/
 src/content/docs/contributor-guide/
 src/content/docs/user-guide/
 src/sonarwhal-theme-optimized/
+src/content-replaced
 Thumbs.db

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ sonarwhalRepoRoot: https://github.com/sonarwhal/sonarwhal
 sonarwhalRoot: https://sonarwhal.com
 
 # Directory
-source_dir: src/content
+source_dir: src/content-replaced
 public_dir: dist
 tag_dir: tags
 archive_dir: archives


### PR DESCRIPTION

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

Fix #377

* Move images in gulp task
* Update images links in .md files
* Hexo builds from the md files with updated image links

https://github.com/sonarwhal/sonarwhal/pull/794 has to be merged first so that the `revreplace` works int he markdown files.

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
