### PR TITLE
Fix: Make links to "more information" in Vulnerable JS audit clickable

### DIFF
--- a/src/sonarwhal-theme/helper/index.js
+++ b/src/sonarwhal-theme/helper/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable object-shorthand, prefer-template */
+const Handlebars = require('handlebars');
 const pagination = require('./pagination');
 const url = require('url');
 
@@ -273,6 +274,25 @@ module.exports = function () {
         },
         isPending: (status) => {
             return status === jobStatus.pending;
+        },
+        linkify: (msg) => {
+            const regex = /(https?:\/\/[a-zA-Z0-9.\\/?:@\-_=#]+\.[a-zA-Z0-9&.\\/?:@-_=#]*)\s[a-zA-Z]/g;
+            // Modified use of regular expression in https://stackoverflow.com/a/39220764
+            // Should match:
+            // jQuery@2.1.4 has 2 known vulnerabilities (1 medium, 1 low). See https://snyk.io/vuln/npm:jquery for more information.
+            // AngularJS@1.4.9 has 3 known vulnerabilities (3 high). See https://snyk.io/vuln/npm:angular for more information.
+            // Shouldn't match (shortened url):
+            // File https://www.odysys.com/ … hedule-Your-Demo-Now.png could be around 37.73kB (78%) smaller.
+            const match = regex.exec(msg);
+
+            if (!match) {
+                return msg;
+            }
+
+            const urlMatch = Handlebars.Utils.escapeExpression(match.pop());
+            const newMsg = msg.replace(urlMatch, '<a href="' + urlMatch + '">' + urlMatch + '</a>');
+
+            return new Handlebars.SafeString(newMsg);
         },
         noIssue: (category) => {
             return category.rules.every((rule) => {

--- a/src/sonarwhal-theme/layout/partials/scan-result-item.hbs
+++ b/src/sonarwhal-theme/layout/partials/scan-result-item.hbs
@@ -13,17 +13,14 @@
     <div class="rule-result--details__body">
         <p class="{{../status}}-badge uppercase-text">{{../status}}</p>
         <p>
-            {{message}}
+            {{{linkify message}}}
         </p>
         {{#if resource}}
-        <div class="rule-result__code">
-
-            <p>
-                <a target="_blank" rel="noopener noreferrer" href="{{resource}}">
-                    {{cutUrlString resource}}{{normalizePosition location.line}}{{normalizePosition location.column}}
-                </a>
-            </p>
-        </div>
+        <p>
+            <a target="_blank" rel="noopener noreferrer" href="{{resource}}">
+                {{cutUrlString resource}}{{normalizePosition location.line}}{{normalizePosition location.column}}
+            </a>
+        </p>
         {{/if}}
         {{#if sourceCode}}
         <div class="rule-result__code">

--- a/src/sonarwhal-theme/layout/scan.hbs
+++ b/src/sonarwhal-theme/layout/scan.hbs
@@ -24,7 +24,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/xml.min.js"></script>
 
-    <script src="/scanner/helpers/compare,cutCodeString,cutString,cutUrlString,getLength,normalizePosition,pluralize,reverseString,shortenString"></script>
+    <script src="/scanner/helpers/compare,cutCodeString,cutString,cutUrlString,getLength,normalizePosition,pluralize,reverseString,shortenString,linkify"></script>
     <!-- build:js /static/scripts/scanner.js -->
     <script src="/js/scanner-common.js"></script>
     <script src="/js/scanner-submit.js"></script>


### PR DESCRIPTION


<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)
Fix #295
<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
