### PR TITLE
Fix: Spacing between details and headings

### DIFF
--- a/src/sonarwhal-theme/source/core/css/base.css
+++ b/src/sonarwhal-theme/source/core/css/base.css
@@ -30,6 +30,12 @@ details {
     display: block;
 }
 
+h2 + details,
+h3 + details,
+p + details {
+    margin-top: 2.4rem;
+}
+
 /* Style focusable elements that need focus ring. Others reset and receive border styles in controls/color.css */
 a:focus,
 li:focus,

--- a/src/sonarwhal-theme/source/core/css/base.css
+++ b/src/sonarwhal-theme/source/core/css/base.css
@@ -30,6 +30,10 @@ details {
     display: block;
 }
 
+details + details {
+    margin-top: 1.6rem;
+}
+
 h2 + details,
 h3 + details,
 p + details {


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)
Add CSS to add a margin above the first details element after
a heading or a paragraph.

Fix #371
Close #371

