### PR TITLE
Fix: Escape html tags

### DIFF
--- a/src/sonarwhal-theme/helper/index.js
+++ b/src/sonarwhal-theme/helper/index.js
@@ -284,13 +284,15 @@ module.exports = function () {
             // Shouldn't match (shortened url):
             // File https://www.odysys.com/ … hedule-Your-Demo-Now.png could be around 37.73kB (78%) smaller.
             const match = regex.exec(msg);
+            const escapedMsg = Handlebars.Utils.escapeExpression(msg);
 
             if (!match) {
-                return msg;
+                return escapedMsg;
             }
 
-            const urlMatch = Handlebars.Utils.escapeExpression(match.pop());
-            const newMsg = msg.replace(urlMatch, '<a href="' + urlMatch + '">' + urlMatch + '</a>');
+            const urlMatch = match.pop();
+            const escapedUrlMatch = Handlebars.Utils.escapeExpression(urlMatch);
+            const newMsg = escapedMsg.replace(escapedUrlMatch, '<a href="' + urlMatch + '">' + escapedUrlMatch + '</a>');
 
             return new Handlebars.SafeString(newMsg);
         },


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->

The HTML tags in the messages were not escaped properly. Just found it today at https://sonarwhal.com/scanner/9f0a520f-b054-4f5e-b54d-d9f233026bb4. The change below should fix it. :(
