### PR TITLE
Fix: Fix the docsearch scraper

### DIFF
--- a/helpers/run-docsearch-scraper.js
+++ b/helpers/run-docsearch-scraper.js
@@ -26,6 +26,7 @@ const DOC_SEARCH_CONFIGS = JSON.stringify({
     index_name: 'sonarwhal',
     min_indexed_level: 1,
     nb_hits: 459,
+    nb_hits_max: 100000,
     selectors: {
         lvl0: 'nav .guide-category',
         lvl1: '.page-intro h1',


### PR DESCRIPTION
Fix #398

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

This is caused by a code change in the docsearch scraper. Before https://github.com/algolia/docsearch-scraper/pull/368 is merged, we can set a `nb_hits_max` so that the scrape can still complete.

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
