### PR TITLE
Fix: Add trailing `/` if missing

### DIFF
--- a/web.config
+++ b/web.config
@@ -195,11 +195,7 @@
                     </conditions>
                     <action type="Rewrite" url="dist{REQUEST_URI}.gz"/>
                 </rule>
-                <!-- Fallback in case the user agent doesn't support compression -->
-                <rule name="static">
-                    <match url="(?!scanner|search).*$" ignoreCase="true"/>
-                    <action type="Rewrite" url="dist{REQUEST_URI}"/>
-                </rule>
+
                 <!-- If the user agent reaches a /scanner or /search page, it should be handled by our node server -->
                 <rule name="ScannerAndSearch" stopProcessing="true">
                     <match url="(?:scanner|search)(.*)$" ignoreCase="true"/>
@@ -207,6 +203,37 @@
                         <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="True"/>
                     </conditions>
                     <action type="Rewrite" url="src/server/index.js"/>
+                </rule>
+                <!-- We want to add a trailing slash to the urls that do not have it and are not files (i.e. contain a ".") so we don't end up in a 404 page -->
+                <rule name="Add trailing slash" stopProcessing="true">
+                    <match url="(.*)"/>
+                    <conditions>
+                        <add input="{REQUEST_URI}" pattern="(\..*$|.*\/$)" negate="true" />
+                    </conditions>
+                    <action type="Redirect" redirectType="Permanent" url="{R:1}/" />
+                </rule>
+                <!--
+                    We don't link to any `.html` page so we assume that all pages ending on `/` are going to point to a `index.html` file
+                    The ^$ is for the homepage. Also, we add this at the end so /scanner/ and /search/ are served correctly via node
+                -->
+                <rule name="ServeCompressedHTMLBrotli" stopProcessing="true">
+                    <match url="(^(.*\/)$|^$)" />
+                    <conditions>
+                        <add input="{HTTP_ACCEPT_ENCODING}" pattern="br" negate="false" />
+                    </conditions>
+                    <action type="Rewrite" url="dist{REQUEST_URI}index.html.br"/>
+                </rule>
+                <rule name="ServeCompressedHTMLZopfli" stopProcessing="true">
+                    <match url="(^(.*\/)$|^$)" />
+                    <conditions>
+                        <add input="{HTTP_ACCEPT_ENCODING}" pattern="gzip" negate="false" />
+                    </conditions>
+                    <action type="Rewrite" url="dist{REQUEST_URI}index.html.gz"/>
+                </rule>
+                <!-- Fallback in case the user agent doesn't support compression -->
+                <rule name="static">
+                    <match url="(?!scanner|search).*$" ignoreCase="true"/>
+                    <action type="Rewrite" url="dist{REQUEST_URI}"/>
                 </rule>
             </rules>
         </rewrite>


### PR DESCRIPTION
Fix #393

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

Take 2. This file is deployed already (uploaded via FTP) and everything seems to work now.
<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
