### PR TITLE
Fix: Endless redirect loop with querystrings

### DIFF
--- a/web.config
+++ b/web.config
@@ -208,7 +208,7 @@
                 <rule name="Add trailing slash" stopProcessing="true">
                     <match url="(.*)"/>
                     <conditions>
-                        <add input="{REQUEST_URI}" pattern="(\..*$|.*\/$)" negate="true" />
+                        <add input="{REQUEST_URI}" pattern="(\..*$|.*\/$|\?)" negate="true" />
                     </conditions>
                     <action type="Redirect" redirectType="Permanent" url="{R:1}/" />
                 </rule>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

## Short description of the change(s)

Fix #431

This doesn't take into account the case where we have something like:

https://sonarwhal.com/docs?utm_source=CSS-Weekly&utm_campaign=Issue-290&utm_medium=RSS

But so far in the webmaster tools I haven't seen anything. If we start seeing links like that one I'll think of something, but it wasn't trivial to fix.

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
