### PR TITLE
typo crossorigin anonymouss

### DIFF
--- a/src/sonarwhal-theme/layout/scan.hbs
+++ b/src/sonarwhal-theme/layout/scan.hbs
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="/core/css/scanner.css">
     <link rel="stylesheet" href="/core/css/scan-results.css">
     <!-- endbuild -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css" rel="stylesheet" integrity="sha384-zhIsEafzyQWHSoMCQ4BfT8ZlRXQyIFwAHAJn32PNdsb8n6tVysGZSLpEEIvCskw4" crossorigin="anonymouss">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css" rel="stylesheet" integrity="sha384-zhIsEafzyQWHSoMCQ4BfT8ZlRXQyIFwAHAJn32PNdsb8n6tVysGZSLpEEIvCskw4" crossorigin="anonymous">
 </head>
 
 <body>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [ ] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages) (not checked because of dead link)

## Short description of the change(s)

This should solve the easiest issue reported in #434.

```
Attribute "crossorigin" doesn't have a valid value, should "anonymous" or "use-credentials": crossorigin="anonymouss"
```

anonymouss replaced with anonymous

<!--

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
