### PR TITLE
Add Source Sans Pro to styles

### DIFF
--- a/src/sonarwhal-theme/layout/partials/styles.hbs
+++ b/src/sonarwhal-theme/layout/partials/styles.hbs
@@ -16,5 +16,5 @@
 <link rel="stylesheet" href="/core/css/controls.css">
 <link rel="stylesheet" href="/core/css/scanner.css">
 <!-- endbuild -->
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,500|Source+Sans+Pro" integrity="sha384-6hCj8YZdGj+SQ9wB8ShBR1XRd+tUsQSfKu1i4C72EaUKO6AeEipi63+OPsdZPLoD" crossorigin="anonymous">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,500|Source+Sans+Pro" integrity="sha384-KfN8k2PKf2Ze/0sCe/2VHfHet5sTnHszVhdKaRwov2a9VdEZJJfvc7gZxaZbBl1J" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" integrity="sha384-mHx5KeR3zcLviQFPmpHqrwf2uxtukRvUFVzOMOqIjKjSNrurxlmJ3oS+vm49Mz07" crossorigin="anonymous">

--- a/src/sonarwhal-theme/layout/partials/styles.hbs
+++ b/src/sonarwhal-theme/layout/partials/styles.hbs
@@ -16,6 +16,5 @@
 <link rel="stylesheet" href="/core/css/controls.css">
 <link rel="stylesheet" href="/core/css/scanner.css">
 <!-- endbuild -->
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro"> 
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,500" integrity="sha384-6hCj8YZdGj+SQ9wB8ShBR1XRd+tUsQSfKu1i4C72EaUKO6AeEipi63+OPsdZPLoD" crossorigin="anonymous">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,500|Source+Sans+Pro" integrity="sha384-6hCj8YZdGj+SQ9wB8ShBR1XRd+tUsQSfKu1i4C72EaUKO6AeEipi63+OPsdZPLoD" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" integrity="sha384-mHx5KeR3zcLviQFPmpHqrwf2uxtukRvUFVzOMOqIjKjSNrurxlmJ3oS+vm49Mz07" crossorigin="anonymous">

--- a/src/sonarwhal-theme/layout/partials/styles.hbs
+++ b/src/sonarwhal-theme/layout/partials/styles.hbs
@@ -16,5 +16,6 @@
 <link rel="stylesheet" href="/core/css/controls.css">
 <link rel="stylesheet" href="/core/css/scanner.css">
 <!-- endbuild -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro"> 
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,500" integrity="sha384-6hCj8YZdGj+SQ9wB8ShBR1XRd+tUsQSfKu1i4C72EaUKO6AeEipi63+OPsdZPLoD" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" integrity="sha384-mHx5KeR3zcLviQFPmpHqrwf2uxtukRvUFVzOMOqIjKjSNrurxlmJ3oS+vm49Mz07" crossorigin="anonymous">

--- a/src/sonarwhal-theme/layout/partials/styles.hbs
+++ b/src/sonarwhal-theme/layout/partials/styles.hbs
@@ -16,5 +16,5 @@
 <link rel="stylesheet" href="/core/css/controls.css">
 <link rel="stylesheet" href="/core/css/scanner.css">
 <!-- endbuild -->
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:200,300,400,500|Source+Sans+Pro" integrity="sha384-KfN8k2PKf2Ze/0sCe/2VHfHet5sTnHszVhdKaRwov2a9VdEZJJfvc7gZxaZbBl1J" crossorigin="anonymous">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat:300,400,500|Source+Sans+Pro" integrity="sha384-KfN8k2PKf2Ze/0sCe/2VHfHet5sTnHszVhdKaRwov2a9VdEZJJfvc7gZxaZbBl1J" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" integrity="sha384-mHx5KeR3zcLviQFPmpHqrwf2uxtukRvUFVzOMOqIjKjSNrurxlmJ3oS+vm49Mz07" crossorigin="anonymous">

--- a/src/sonarwhal-theme/source/core/css/scan-results.css
+++ b/src/sonarwhal-theme/source/core/css/scan-results.css
@@ -61,7 +61,7 @@
 
 [class*="scan-overview__body--"] {
     font-size: 4.8rem;
-    font-weight: 200;
+    font-weight: 300;
     margin-top: .2rem;
     letter-spacing: .03rem;
     text-transform: uppercase;
@@ -204,7 +204,7 @@
     max-width: 19rem;
     margin-bottom: 1rem;
     font-size: 1.4rem;
-    font-weight: 600;
+    font-weight: 500;
     letter-spacing: .07rem;
 
     overflow: hidden;

--- a/src/sonarwhal-theme/source/core/css/type.css
+++ b/src/sonarwhal-theme/source/core/css/type.css
@@ -107,9 +107,7 @@ caption,
     line-height: 1.2;
 }
 
-h3,
 h4,
-.title,
 .subtitle,
 .subtitle--alt {
     font-weight: 300;
@@ -117,10 +115,11 @@ h4,
 
 h5,
 h6,
+thead th,
 .caption,
 .subcaption,
 .subcaption {
-    font-weight: 400;
+    font-weight: 500;
 }
 
 .headline {

--- a/src/sonarwhal-theme/source/core/css/type.css
+++ b/src/sonarwhal-theme/source/core/css/type.css
@@ -13,7 +13,7 @@ html {
 
 /* use em rather than rem due to IE9–10 rem in font shorthand bug. */
 body {
-    font: 1.8em/1.4 base, "Source Sans Pro", Verdana, sans-serif;
+    font: 1.8em/1.4 base, "Source Sans Pro", Arial, sans-serif;
 }
 
 /*	Headings and Captions */


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonarwhal)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

Fix #460
The code to Source Sans Pro was removed at some point but it is still
defined as the main font for the body of the site.

Added Arial in replacement of Verdana for a fallback font since it is
proportionally very different from Source Sans Pro and the current type
scale makes Verdana seem very large compared to the headings.
